### PR TITLE
Implement Observable and useObserver

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,4 +19,7 @@ export const Obsidian = new _Obsidian();
 export { injectComponent } from './injectors/components/InjectComponent';
 export { injectHook, injectHookWithArguments } from './injectors/hooks/InjectHook';
 
+export { useObserver } from './observable/useObserver';
+export { Observable, OnNext } from './observable/Observable';
+
 export { testKit } from '../testkit';

--- a/src/observable/Observable.ts
+++ b/src/observable/Observable.ts
@@ -1,0 +1,26 @@
+/* eslint-disable no-underscore-dangle */
+export type OnNext<T> = (value: T) => void;
+type Unsubscribe = () => void;
+
+export class Observable<T> {
+  private subscribers: Set<OnNext<T>> = new Set();
+
+  constructor(private _value: T) {}
+
+  public get value(): T {
+    return this._value;
+  }
+
+  public set value(value: T) {
+    this._value = value;
+    this.subscribers.forEach((subscriber) => subscriber(value));
+  }
+
+  public subscribe(onNext: OnNext<T>): Unsubscribe {
+    if (this.subscribers.has(onNext)) {
+      throw new Error('Subscriber already subscribed');
+    }
+    this.subscribers.add(onNext);
+    return () => this.subscribers.delete(onNext);
+  }
+}

--- a/src/observable/observable.test.ts
+++ b/src/observable/observable.test.ts
@@ -1,0 +1,52 @@
+import { Observable } from './Observable';
+
+describe('makeObservable', () => {
+  it('should make observable', () => {
+    const obj = {};
+    const observable = new Observable(obj);
+    expect(observable).toBeInstanceOf(Observable);
+  });
+
+  it('should expose the observed value', () => {
+    const obj = {};
+    const observable = new Observable(obj);
+    expect(observable.value).toBe(obj);
+  });
+
+  it('should be observable', () => {
+    const observable = new Observable({});
+    let observedValue: any = null;
+    observable.subscribe((value) => {
+      observedValue = value;
+    });
+    expect(observedValue).toBe(null);
+    const newValue = {};
+    observable.value = newValue;
+    expect(observedValue).toBe(newValue);
+  });
+
+  it('should be observable with multiple subscribers', () => {
+    const observable = new Observable({});
+    let observedValue1: any = null;
+    let observedValue2: any = null;
+    observable.subscribe((value) => {
+      observedValue1 = value;
+    });
+    observable.subscribe((value) => {
+      observedValue2 = value;
+    });
+    expect(observedValue1).toBe(null);
+    expect(observedValue2).toBe(null);
+    const newValue = {};
+    observable.value = newValue;
+    expect(observedValue1).toBe(newValue);
+    expect(observedValue2).toBe(newValue);
+  });
+
+  it('should subscribe only once', () => {
+    const observable = new Observable({});
+    const subscriber = () => {};
+    observable.subscribe(subscriber);
+    expect(() => observable.subscribe(subscriber)).toThrowError('Subscriber already subscribed');
+  });
+});

--- a/src/observable/useObserver.test.ts
+++ b/src/observable/useObserver.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react-hooks';
+import _ from 'lodash';
+import { Observable } from './Observable';
+import { useObserver } from './useObserver';
+
+describe('useObserver', () => {
+  const object = {
+    count: 0,
+  };
+
+  let observable: Observable<typeof object>;
+
+  const uut = () => {
+    const [count] = useObserver(observable);
+    return count;
+  };
+
+  beforeEach(() => {
+    observable = new Observable(object);
+  });
+
+  it('should return the current value', () => {
+    const { result } = renderHook(uut);
+    expect(result.current.count).toBe(0);
+  });
+
+  it('should update the value', () => {
+    const { result, rerender } = renderHook(uut);
+    expect(result.current.count).toBe(0);
+    observable.value = {
+      count: 1,
+    };
+    rerender();
+    expect(result.current.count).toBe(1);
+  });
+
+  it('should clear the subscription on unmount', () => {
+    const { unmount } = renderHook(uut);
+    expect(_.get(observable, 'subscribers.size')).toBe(1);
+    unmount();
+    expect(_.get(observable, 'subscribers.size', 0)).toBe(0);
+  });
+});

--- a/src/observable/useObserver.ts
+++ b/src/observable/useObserver.ts
@@ -1,0 +1,17 @@
+/* eslint-disable no-param-reassign */
+import { useCallback, useEffect, useState } from 'react';
+import { Observable } from './Observable';
+
+export function useObserver<T>(observable: Observable<T>): [T, (next: T) => void] {
+  const [value, setValue] = useState(observable.value);
+  const onNext = useCallback((next: T) => {
+    setValue(next);
+    observable.value = value;
+  }, [observable]);
+
+  useEffect(() => {
+    return observable.subscribe(setValue);
+  }, [observable]);
+
+  return [value, onNext];
+}


### PR DESCRIPTION
This PR introduces two new constructs related to reactivity - an `Observable` and a `useObserver` hook.

The `Observable` class lets developers respond to changes in some value, typically a class property. The `useObserver` hook is a wrapper around the new `Observable` class meant to be used in hooks.

### API
```ts
const object = {
    count: 0,
};

const observable = new Observable(object);

const myHook = () => {
    const [count] = useObserver(observable);
    console.log(count); // 0, 1, 2
};

observable.value = 1;
observable.value = 2;
```