### PR TITLE
implement ObservableMediator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ export { injectComponent } from './injectors/components/InjectComponent';
 export { injectHook, injectHookWithArguments } from './injectors/hooks/InjectHook';
 
 export { useObserver } from './observable/useObserver';
-export { Observable, OnNext } from './observable/Observable';
+export { Observable } from './observable/Observable';
+export { ObservableMediator } from './observable/ObservableMediator';
+export { OnNext, Unsubscribe } from './observable/types';
 
 export { testKit } from '../testkit';

--- a/src/observable/Observable.ts
+++ b/src/observable/Observable.ts
@@ -1,18 +1,19 @@
-/* eslint-disable no-underscore-dangle */
-export type OnNext<T> = (value: T) => void;
-type Unsubscribe = () => void;
+import { Observable as IObservable, OnNext, Unsubscribe } from './types';
 
-export class Observable<T> {
+export class Observable<T> implements IObservable<T> {
   private subscribers: Set<OnNext<T>> = new Set();
+  private currentValue: T | undefined;
 
-  constructor(private _value: T) {}
+  constructor(initialValue?: T) {
+    this.currentValue = initialValue;
+  }
 
   public get value(): T {
-    return this._value;
+    return this.currentValue as T;
   }
 
   public set value(value: T) {
-    this._value = value;
+    this.currentValue = value;
     this.subscribers.forEach((subscriber) => subscriber(value));
   }
 

--- a/src/observable/ObservableMediator.test.ts
+++ b/src/observable/ObservableMediator.test.ts
@@ -1,0 +1,96 @@
+import { Observable } from './Observable';
+import { ObservableMediator } from './ObservableMediator';
+
+const NOOP = () => {};
+
+describe('ObservableMediator', () => {
+  let uut!: ObservableMediator<number>;
+
+  beforeEach(() => {
+    uut = new ObservableMediator();
+  });
+
+  it('should be defined', () => {
+    expect(ObservableMediator).toBeDefined();
+  });
+
+  it('should be instantiable', () => {
+    expect(uut).toBeInstanceOf(ObservableMediator);
+  });
+
+  it('should have a value property', () => {
+    uut.value = 1;
+    expect(uut.value).toBeDefined();
+  });
+
+  it('should have a value property that can be set', () => {
+    uut.value = 1;
+    expect(uut.value).toEqual(1);
+  });
+
+  it('should have a value property that can be set to a different value', () => {
+    uut.value = 1;
+    uut.value = 2;
+    expect(uut.value).toEqual(2);
+  });
+
+  it('should support observing other observables', () => {
+    const observable = new Observable(1);
+    uut.addSource(observable, (next: number) => {
+      uut.value = next;
+    });
+
+    let value!: number;
+    uut.subscribe((next) => {
+      value = next;
+    });
+    observable.value = 2;
+    expect(value).toEqual(2);
+    expect(uut.value).toEqual(2);
+  });
+
+  it('should support observing other observables and transforming the value', () => {
+    const a = new Observable<number>();
+    const b = new Observable<number>();
+    const c = new Observable<number>();
+
+    uut.addSource(a, (nextA) => {
+      uut.value = nextA;
+    });
+    uut.addSource(b, (nextB) => {
+      uut.value *= nextB;
+    });
+    uut.addSource(c, (nextC) => {
+      uut.value *= nextC;
+    });
+
+    uut.subscribe(() => {});
+    a.value = 1;
+    expect(uut.value).toEqual(1);
+    b.value = 2;
+    expect(uut.value).toEqual(2);
+    c.value = -1;
+    expect(uut.value).toEqual(-2);
+  });
+
+  it('should unsubscribe from all sources when unsubscribed', () => {
+    const a = new Observable<number>();
+    const b = new Observable<number>();
+
+    uut.addSource(a, NOOP);
+    uut.addSource(b, NOOP);
+
+    const unsubscribe = uut.subscribe(NOOP);
+    unsubscribe();
+    expect(Reflect.get(a, 'subscribers').size).toEqual(0);
+    expect(Reflect.get(b, 'subscribers').size).toEqual(0);
+  });
+
+  it('should throw an error if a subscriber is already subscribed', () => {
+    const subscriber = () => {};
+    uut.subscribe(subscriber);
+    expect(() => uut.subscribe(subscriber)).toThrowError(
+      'Subscriber already subscribed',
+    );
+  });
+});

--- a/src/observable/ObservableMediator.test.ts
+++ b/src/observable/ObservableMediator.test.ts
@@ -93,4 +93,22 @@ describe('ObservableMediator', () => {
       'Subscriber already subscribed',
     );
   });
+
+  it('should mediate between observers of different types', () => {
+    const a = new Observable<number>();
+    const b = new Observable<string>();
+
+    uut.addSource(a, (nextA: number) => {
+      uut.value = nextA;
+    });
+    uut.addSource(b, (nextB) => {
+      uut.value = parseInt(nextB, 10);
+    });
+
+    uut.subscribe(() => {});
+    a.value = 1;
+    expect(uut.value).toEqual(1);
+    b.value = '2';
+    expect(uut.value).toEqual(2);
+  });
 });

--- a/src/observable/ObservableMediator.test.ts
+++ b/src/observable/ObservableMediator.test.ts
@@ -118,4 +118,9 @@ describe('ObservableMediator', () => {
 
     uut.addSource(a, NOOP).addSource(b, NOOP);
   });
+
+  it('supports passing initial value in through the constructor', () => {
+    const mediator = new ObservableMediator(1);
+    expect(mediator.value).toEqual(1);
+  });
 });

--- a/src/observable/ObservableMediator.test.ts
+++ b/src/observable/ObservableMediator.test.ts
@@ -111,4 +111,11 @@ describe('ObservableMediator', () => {
     b.value = '2';
     expect(uut.value).toEqual(2);
   });
+
+  it('should support chaining addSource calls', () => {
+    const a = new Observable();
+    const b = new Observable();
+
+    uut.addSource(a, NOOP).addSource(b, NOOP);
+  });
 });

--- a/src/observable/ObservableMediator.ts
+++ b/src/observable/ObservableMediator.ts
@@ -12,6 +12,10 @@ export class ObservableMediator<T> implements IObservable<T> {
   private currentValue!: T;
   private sources: Source<any>[] = [];
 
+  constructor(initialValue?: T) {
+    this.currentValue = initialValue as T;
+  }
+
   addSource<S>(source: Observable<S>, onNext: OnNext<S>): ObservableMediator<T> {
     this.sources.push({ source, onNext });
     return this;

--- a/src/observable/ObservableMediator.ts
+++ b/src/observable/ObservableMediator.ts
@@ -12,8 +12,9 @@ export class ObservableMediator<T> implements IObservable<T> {
   private currentValue!: T;
   private sources: Source<any>[] = [];
 
-  addSource<S>(source: Observable<S>, onNext: OnNext<S>) {
+  addSource<S>(source: Observable<S>, onNext: OnNext<S>): ObservableMediator<T> {
     this.sources.push({ source, onNext });
+    return this;
   }
 
   public get value(): T {

--- a/src/observable/ObservableMediator.ts
+++ b/src/observable/ObservableMediator.ts
@@ -10,9 +10,9 @@ type Source<T> = {
 export class ObservableMediator<T> implements IObservable<T> {
   private subscribers: Set<OnNext<T>> = new Set();
   private currentValue!: T;
-  private sources: Source<T>[] = [];
+  private sources: Source<any>[] = [];
 
-  addSource(source: Observable<T>, onNext: OnNext<T>) {
+  addSource<S>(source: Observable<S>, onNext: OnNext<S>) {
     this.sources.push({ source, onNext });
   }
 

--- a/src/observable/ObservableMediator.ts
+++ b/src/observable/ObservableMediator.ts
@@ -1,0 +1,50 @@
+import { Observable } from './Observable';
+import { OnNext, Unsubscribe, Observable as IObservable } from './types';
+
+type Source<T> = {
+  source: Observable<T>;
+  onNext: OnNext<T>;
+  unsubscribe?: Unsubscribe;
+};
+
+export class ObservableMediator<T> implements IObservable<T> {
+  private subscribers: Set<OnNext<T>> = new Set();
+  private currentValue!: T;
+  private sources: Source<T>[] = [];
+
+  addSource(source: Observable<T>, onNext: OnNext<T>) {
+    this.sources.push({ source, onNext });
+  }
+
+  public get value(): T {
+    return this.currentValue;
+  }
+
+  public set value(value: T) {
+    this.currentValue = value;
+    this.subscribers.forEach((subscriber) => subscriber(value));
+  }
+
+  subscribe(onNext: OnNext<T>): Unsubscribe {
+    if (this.subscribers.has(onNext)) {
+      throw new Error('Subscriber already subscribed');
+    }
+    this.subscribers.add(onNext);
+
+    this.subscribeToAllSources();
+
+    return () => {
+      this.subscribers.delete(onNext);
+      this.sources.forEach(({ unsubscribe }) => unsubscribe?.());
+    };
+  }
+
+  private subscribeToAllSources() {
+    this.sources.forEach(({ source, onNext }, index) => {
+      const unsubscribe = source.subscribe((value) => {
+        onNext(value);
+      });
+      this.sources[index].unsubscribe = unsubscribe;
+    });
+  }
+}

--- a/src/observable/types.ts
+++ b/src/observable/types.ts
@@ -1,0 +1,7 @@
+export type OnNext<T> = (value: T) => void;
+export type Unsubscribe = () => void;
+
+export interface Observable<T> {
+  value: T;
+  subscribe(onNext: OnNext<T>): Unsubscribe;
+}


### PR DESCRIPTION
The new ObservableMediator  allows for creating a new observable based on an existing one. This is useful when certain elements of the state of derived from other elements.

### API

```ts
const a = new Observable<number>();
const b = new Observable<number>();

const mediator = new ObservableMediator<number>(1);
mediator.addSource(a, (next: number) => { mediator.value *= next; });
mediator.addSource(b,(next: number) => { mediator.value *= next; });

a.value = -1;
console.log(mediator.value); // -1
b.value = 2;
console.log(mediator.value); // -2
```

#### addSource calls can be chained
```ts
const mediator = new ObservableMediator<number>(1)
    .addSource(a, (next: number) => { mediator.value *= next; })
    .addSource(b,(next: number) => { mediator.value *= next; });
```