### PR TITLE
Implement graph.onBind()

### DIFF
--- a/src/graph/Graph.ts
+++ b/src/graph/Graph.ts
@@ -2,4 +2,5 @@ import PropertyRetrieverDelegate from './PropertyRetrieverDelegate';
 
 export interface Graph extends PropertyRetrieverDelegate {
   get name(): string;
+  onBind(target: any): void;
 }

--- a/src/graph/ObjectGraph.ts
+++ b/src/graph/ObjectGraph.ts
@@ -20,6 +20,10 @@ export abstract class ObjectGraph<T = unknown> implements Graph {
   retrieve<Dependency>(property: string, receiver?: unknown): Dependency | undefined {
     return this.propertyRetriever.retrieve(property, receiver) as Dependency | undefined;
   }
+
+  onBind(_target: any) {
+
+  }
 }
 
 Reflect.set(ObjectGraph, 'typeDiscriminator', 'ObjectGraph');

--- a/src/injectors/class/ClassInjector.ts
+++ b/src/injectors/class/ClassInjector.ts
@@ -26,6 +26,7 @@ export default class ClassInjector {
         const graph = graphRegistry.resolve(Graph);
         Reflect.defineMetadata(GRAPH_INSTANCE_NAME_KEY, graph.name, target);
         const argsToInject = this.injectConstructorArgs(args, graph, target);
+        graph.onBind(target);
         const createdObject = Reflect.construct(target, argsToInject, newTarget);
         this.injectProperties(target, createdObject, graph);
         return createdObject;

--- a/src/injectors/components/ComponentInjector.test.tsx
+++ b/src/injectors/components/ComponentInjector.test.tsx
@@ -1,6 +1,8 @@
 import { render } from '@testing-library/react';
 import React, { useRef } from 'react';
+import { GraphWithOnBind } from '../../../test/fixtures/GraphWithOnBind';
 import MainGraph, { Dependencies } from '../../../test/fixtures/MainGraph';
+import { DependenciesOf } from '../../types';
 import { injectComponent } from './InjectComponent';
 
 describe('ComponentInjector', () => {
@@ -65,5 +67,15 @@ describe('ComponentInjector', () => {
     const InjectedComponent = injectComponent(MemoizedComponent, MainGraph);
     const { container } = render(<InjectedComponent />);
     expect(container.textContent).toBe('1 - Fear kills progress');
+  });
+
+  it('Binds component to the graph before providers are resolved', () => {
+    const ComponentToTestOnBind = ({ targetName }: DependenciesOf<GraphWithOnBind, 'targetName'>) => {
+      return (<>{targetName}</>);
+    };
+
+    const InjectedComponent = injectComponent(ComponentToTestOnBind, GraphWithOnBind);
+    const { container } = render(<InjectedComponent />);
+    expect(container.textContent).toBe('ComponentToTestOnBind');
   });
 });

--- a/src/injectors/components/ComponentInjector.tsx
+++ b/src/injectors/components/ComponentInjector.tsx
@@ -25,7 +25,7 @@ export default class ComponentInjector {
     const compare = isMemoized ? InjectionCandidate.compare : undefined;
 
     return genericMemo((passedProps: P) => {
-      const graph = useGraph<P>(Graph, passedProps);
+      const graph = useGraph<P>(Graph, Target, passedProps);
       const proxiedProps = new PropsInjector(graph).inject(passedProps);
 
       return <>{Target(proxiedProps as unknown as PropsWithChildren<P>)}</>;

--- a/src/injectors/components/useGraph.ts
+++ b/src/injectors/components/useGraph.ts
@@ -4,8 +4,12 @@ import { ObjectGraph } from '../../graph/ObjectGraph';
 import graphRegistry from '../../graph/registry/GraphRegistry';
 import referenceCounter from '../../ReferenceCounter';
 
-export default <P>(Graph: Constructable<ObjectGraph>, props?: Partial<P>) => {
-  const [graph] = useState(graphRegistry.resolve(Graph, props));
+export default <P>(Graph: Constructable<ObjectGraph>, target: any, props?: Partial<P>) => {
+  const [graph] = useState(() => {
+    const resolveGraph = graphRegistry.resolve(Graph, props);
+    resolveGraph.onBind(target);
+    return resolveGraph;
+  });
   useEffect(() => {
     referenceCounter.retain(graph);
     return () => referenceCounter.release(graph, (g) => graphRegistry.clear(g));

--- a/src/injectors/hooks/HookInjector.test.ts
+++ b/src/injectors/hooks/HookInjector.test.ts
@@ -7,6 +7,7 @@ import HookInjector from './HookInjector';
 import MainGraph from '../../../test/fixtures/MainGraph';
 import { DependenciesOf } from '../../types';
 import { LifecycleBoundGraph } from '../../../test/fixtures/LifecycleBoundGraph';
+import { GraphWithOnBind } from '../../../test/fixtures/GraphWithOnBind';
 
 describe('Hook injection', () => {
   let uut: HookInjector;
@@ -34,6 +35,14 @@ describe('Hook injection', () => {
     }, { initialProps: { stringFromProps: 'Hey!' } });
 
     expect(result.current.text).toBe('A string passed via props: Hey!');
+  });
+
+  it('Binds hooks to the graph before providers are resolved', () => {
+    const hookToTestOnBind = ({ targetName }: { targetName: string }) => {
+      return targetName;
+    };
+    const { result } = renderHook(() => uut.inject(hookToTestOnBind, GraphWithOnBind)());
+    expect(result.current).toBe('hookToTestOnBind');
   });
 });
 

--- a/src/injectors/hooks/HookInjector.ts
+++ b/src/injectors/hooks/HookInjector.ts
@@ -9,7 +9,7 @@ export default class HookInjector {
     Graph: Constructable<ObjectGraph>,
   ): (args?: Partial<Args>) => Result {
     return (args?: Partial<Args>): Result => {
-      const graph = useGraph(Graph, args);
+      const graph = useGraph(Graph, hook, args);
       return hook(new Proxy(args ?? {}, new Injector(graph)));
     };
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,7 @@ export type ServiceLocator<Clazz> = {
   [Key in keyof Clazz]: () => Clazz[Key] extends (...args: any[]) => infer R ? R : never;
 };
 
-export type GraphInternals = 'retrieve' | 'name' | 'scope';
+export type GraphInternals = 'retrieve' | 'name' | 'scope' | 'onBind';
 
 export type DependenciesOf<G, Dependencies extends keyof DependenciesOf<G> = never> =
   Partial<Dependencies> extends never ?

--- a/test/fixtures/GraphWithOnBind.ts
+++ b/test/fixtures/GraphWithOnBind.ts
@@ -1,0 +1,15 @@
+import { Graph, ObjectGraph, Provides } from '../../src';
+
+@Graph()
+export class GraphWithOnBind extends ObjectGraph {
+  private target!: any;
+
+  override onBind(target: any) {
+    this.target = target;
+  }
+
+  @Provides()
+  targetName(): string {
+    return this.target.name;
+  }
+}

--- a/test/integration/classInjection.test.tsx
+++ b/test/integration/classInjection.test.tsx
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '../../src';
+import { GraphWithOnBind } from '../fixtures/GraphWithOnBind';
 import injectedValues from '../fixtures/injectedValues';
 import MainGraph from '../fixtures/MainGraph';
 
@@ -6,6 +7,11 @@ describe('Class injection', () => {
   it('injects class properties', () => {
     const uut = new SingleArg();
     expect(uut.someString).toBe(injectedValues.fromStringProvider);
+  });
+
+  it('Binds to the graph before injecting properties', () => {
+    const uut = new ClassToTestOnBind();
+    expect(uut.targetName).toBe('ClassToTestOnBind');
   });
 
   // it('injects constructor arguments', () => {
@@ -30,6 +36,11 @@ describe('Class injection', () => {
   //   expect(uut.someString).toBe(injectedValues.fromStringProvider);
   //   expect(uut.anotherString).toBe(injectedValues.anotherString);
   // });
+
+  @Injectable(GraphWithOnBind)
+  class ClassToTestOnBind {
+    @Inject() public readonly targetName!: string;
+  }
 
   @Injectable(MainGraph)
   class SingleArg {


### PR DESCRIPTION
The new onBind method is called whenever a graph is resolved for an injection target. onBind is guaranteed to be called once, even if nothing is injected.

closes #8 