### PR TITLE
Pass props to graph constructor when injecting class components

### DIFF
--- a/src/injectors/class/ClassInjector.ts
+++ b/src/injectors/class/ClassInjector.ts
@@ -23,7 +23,7 @@ export default class ClassInjector {
   ): ProxyHandler<any> {
     return new class Handler implements ProxyHandler<any> {
       construct(target: any, args: any[], newTarget: Function): any {
-        const graph = graphRegistry.resolve(Graph);
+        const graph = graphRegistry.resolve(Graph, args.length > 0 ? args[0] : undefined);
         Reflect.defineMetadata(GRAPH_INSTANCE_NAME_KEY, graph.name, target);
         const argsToInject = this.injectConstructorArgs(args, graph, target);
         graph.onBind(target);

--- a/test/integration/lifecyleBoundGraphs.test.tsx
+++ b/test/integration/lifecyleBoundGraphs.test.tsx
@@ -1,10 +1,15 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import { injectComponent, injectHook } from '../../src';
+import {
+  Inject,
+  Injectable,
+  injectComponent,
+  injectHook,
+} from '../../src';
 import { LifecycleBoundGraph } from '../fixtures/LifecycleBoundGraph';
 
 describe('React lifecycle bound graphs', () => {
-  const Component = createComponent();
+  const Component = createFunctionalComponent();
 
   beforeEach(() => {
     LifecycleBoundGraph.timesCreated = 0;
@@ -24,12 +29,26 @@ describe('React lifecycle bound graphs', () => {
     expect(LifecycleBoundGraph.timesCreated).toBe(2);
   });
 
-  function createComponent() {
+  it('passes props to the component', () => {
+    const { container } = render(<ClassComponent stringFromProps='Obsidian is cool' />);
+    expect(container.textContent).toBe('A string passed via props: Obsidian is cool');
+  });
+
+  function createFunctionalComponent() {
     const useHook = injectHook(() => {}, LifecycleBoundGraph);
 
     return injectComponent(() => {
       useHook();
       return <></>;
     }, LifecycleBoundGraph);
+  }
+
+  @Injectable(LifecycleBoundGraph)
+  class ClassComponent extends React.Component<{ stringFromProps: string }> {
+    @Inject() private computedFromProps!: string;
+
+    override render() {
+      return <>{this.computedFromProps}</>;
+    }
   }
 });


### PR DESCRIPTION
Target args were not passed to the resolved graph. This is a quick fix, a more appropriate solution is to check if the injection target is a React class component, in which case to pass only the first arg (which is the props) otherwise to pass all args.