### PR TITLE
Throw more informative exceptions on circular dependencies

### DIFF
--- a/src/graph/CircularDependenciesDetector.ts
+++ b/src/graph/CircularDependenciesDetector.ts
@@ -2,21 +2,22 @@ import { VisitedNodes } from './VisitedNodes';
 
 export class CircularDependenciesDetector {
   private visitedNodes = new VisitedNodes();
-  private circularDependencyDetected = false;
 
-  constructor(public firstDependencyName: string) {}
+  constructor(public graphName: string) {}
 
-  public visit(graphName: string, dependencyName: string) {
-    this.visitedNodes.visit(graphName, dependencyName);
-  }
-
-  public checkForCircularDependencies(graphName: string, dependencyName: string): boolean {
-    const canVisit = this.visitedNodes.canVisit(graphName, dependencyName);
-    if (!canVisit) this.circularDependencyDetected = true;
-    return canVisit;
+  public visit(graphName: string, dependencyName: string): boolean {
+    return this.visitedNodes.visit(graphName, dependencyName);
   }
 
   public hasCircularDependencies(): boolean {
-    return this.circularDependencyDetected;
+    return this.visitedNodes.isCircularPath();
+  }
+
+  public getDependencies(): string[] {
+    return this.visitedNodes.getNodes();
+  }
+
+  public get firstDependencyName(): string {
+    return this.visitedNodes.getNodes()[0];
   }
 }

--- a/src/graph/PropertyRetriever.test.ts
+++ b/src/graph/PropertyRetriever.test.ts
@@ -34,7 +34,8 @@ describe('PropertyRetriever', () => {
   it('throws on circular dependencies', () => {
     const uut1 = new PropertyRetriever(new CircularDependencyGraph2());
     expect(() => uut1.retrieve('dep1')).toThrowError(
-      /Could not resolve property dep1 from CircularDependencyGraph2\d because of a circular dependency/,
+      // eslint-disable-next-line max-len
+      /Could not resolve dep1 from CircularDependencyGraph2\d because of a circular dependency: dep1 -> dep2 -> dep3 -> dep1/,
     );
   });
 });

--- a/src/graph/PropertyRetrieverDelegate.ts
+++ b/src/graph/PropertyRetrieverDelegate.ts
@@ -4,7 +4,7 @@ interface PropertyRetrieverDelegate {
   retrieve: (
     property: string,
     receiver?: unknown,
-    circularDependencyDetector?: CircularDependenciesDetector
+    circularDependenciesDetector?: CircularDependenciesDetector
   ) => unknown | undefined;
 }
 

--- a/src/graph/VisitedNodes.ts
+++ b/src/graph/VisitedNodes.ts
@@ -1,11 +1,25 @@
 export class VisitedNodes {
-  private visitedNodes = new Set<string>();
+  private visitedNodes = new Set<`${string}.${string}`>();
+  private visitPath: string[] = [];
 
-  public visit(graphName: string, dependencyName: string) {
-    this.visitedNodes.add(`${graphName}.${dependencyName}`);
+  public visit(graphName: string, dependencyName: string): boolean {
+    this.visitPath.push(dependencyName);
+    if (this.canVisit(graphName, dependencyName)) {
+      this.visitedNodes.add(`${graphName}.${dependencyName}`);
+      return true;
+    }
+    return false;
   }
 
   public canVisit(graphName: string, dependencyName: string) {
     return !this.visitedNodes.has(`${graphName}.${dependencyName}`);
+  }
+
+  public isCircularPath(): boolean {
+    return this.visitedNodes.size < this.visitPath.length;
+  }
+
+  getNodes(): string[] {
+    return this.visitPath;
   }
 }

--- a/test/acceptance/obtain.test.ts
+++ b/test/acceptance/obtain.test.ts
@@ -1,4 +1,5 @@
 import { Obsidian } from '../../src';
+import { CircularDependencyFromSubgraph } from '../fixtures/CircularDependencyFromSubgraph';
 import { CircularDependencyGraph } from '../fixtures/CircularDependencyGraph';
 import injectedValues from '../fixtures/injectedValues';
 import MainGraph from '../fixtures/MainGraph';
@@ -16,7 +17,15 @@ describe('obtain', () => {
     expect(
       () => Obsidian.obtain(CircularDependencyGraph).aString(),
     ).toThrowError(
-      /Could not resolve property aString from CircularDependencyGraph\d because of a circular dependency/,
+      // eslint-disable-next-line max-len
+      /Could not resolve aString from CircularDependencyGraph\d because of a circular dependency: aString -> aString$/,
+    );
+  });
+
+  it('describes the circular dependency path in the thrown exception', () => {
+    expect(() => Obsidian.obtain(CircularDependencyFromSubgraph).dep1()).toThrowError(
+      // eslint-disable-next-line max-len
+      /Could not resolve dep1 from CircularDependencyFromSubgraph\d because of a circular dependency: dep1 -> dep2 -> dep3 -> dep2/,
     );
   });
 });

--- a/test/fixtures/CircularDependencyFromSubgraph.ts
+++ b/test/fixtures/CircularDependencyFromSubgraph.ts
@@ -1,0 +1,10 @@
+import { Graph, ObjectGraph, Provides } from '../../src';
+import { SubgraphWithCircularDependency } from './SubgraphWithCircularDependency';
+
+@Graph({ subgraphs: [SubgraphWithCircularDependency] })
+export class CircularDependencyFromSubgraph extends ObjectGraph {
+  @Provides()
+  dep1(dep2: any) {
+    return dep2;
+  }
+}

--- a/test/fixtures/SubgraphWithCircularDependency.ts
+++ b/test/fixtures/SubgraphWithCircularDependency.ts
@@ -1,0 +1,19 @@
+import {
+  Graph,
+  ObjectGraph,
+  Provides,
+  Singleton,
+} from '../../src';
+
+@Singleton() @Graph()
+export class SubgraphWithCircularDependency extends ObjectGraph {
+  @Provides()
+  dep2(dep3: any): any {
+    return dep3;
+  }
+
+  @Provides()
+  dep3(dep2: any): any {
+    return dep2;
+  }
+}


### PR DESCRIPTION
From now on  the "require" path that resulted in a circular dependency will be included in the exception message so what went wrong will be clearer.