### PR TITLE
Fix case where valid dependencies were flagged incorrectly as circular dependencies

### DIFF
--- a/src/graph/CircularDependenciesDetector.ts
+++ b/src/graph/CircularDependenciesDetector.ts
@@ -20,4 +20,8 @@ export class CircularDependenciesDetector {
   public get firstDependencyName(): string {
     return this.visitedNodes.getNodes()[0];
   }
+
+  public clear() {
+    this.visitedNodes.clear();
+  }
 }

--- a/src/graph/PropertyRetriever.ts
+++ b/src/graph/PropertyRetriever.ts
@@ -24,7 +24,9 @@ export default class PropertyRetriever {
           return graph.retrieve(dependencyName, receiver, circularDependenciesDetector);
         },
       });
-      return Reflect.get(this.graph, mangledPropertyKey, receiver)(proxiedGraph);
+      const resolved = Reflect.get(this.graph, mangledPropertyKey, receiver)(proxiedGraph);
+      circularDependenciesDetector.clear();
+      return resolved;
     }
 
     if (circularDependenciesDetector.hasCircularDependencies()) {

--- a/src/graph/VisitedNodes.ts
+++ b/src/graph/VisitedNodes.ts
@@ -19,7 +19,12 @@ export class VisitedNodes {
     return this.visitedNodes.size < this.visitPath.length;
   }
 
-  getNodes(): string[] {
+  public getNodes(): string[] {
     return this.visitPath;
+  }
+
+  public clear() {
+    this.visitedNodes.clear();
+    this.visitPath.length = 0;
   }
 }

--- a/test/acceptance/obtain.test.ts
+++ b/test/acceptance/obtain.test.ts
@@ -1,6 +1,7 @@
 import { Obsidian } from '../../src';
 import { CircularDependencyFromSubgraph } from '../fixtures/CircularDependencyFromSubgraph';
 import { CircularDependencyGraph } from '../fixtures/CircularDependencyGraph';
+import { GraphWithMultipleDependencies } from '../fixtures/GraphWithMultipleDependencies';
 import injectedValues from '../fixtures/injectedValues';
 import MainGraph from '../fixtures/MainGraph';
 
@@ -20,6 +21,12 @@ describe('obtain', () => {
       // eslint-disable-next-line max-len
       /Could not resolve aString from CircularDependencyGraph\d because of a circular dependency: aString -> aString$/,
     );
+  });
+
+  it('Should not throw circular dependency error resolving valid dependencies', () => {
+    expect(
+      Obsidian.obtain(GraphWithMultipleDependencies).theDep(),
+    ).toBe(`prefixSuffix`);
   });
 
   it('describes the circular dependency path in the thrown exception', () => {

--- a/test/fixtures/GraphWithMultipleDependencies.ts
+++ b/test/fixtures/GraphWithMultipleDependencies.ts
@@ -1,0 +1,24 @@
+import { Graph, ObjectGraph, Provides } from '../../src';
+
+@Graph()
+export class GraphWithMultipleDependencies extends ObjectGraph {
+  @Provides()
+  theDep(prefix: string, suffix: string) {
+    return prefix + suffix;
+  }
+
+  @Provides()
+  prefix(noopDep: string) {
+    return `prefix${noopDep}`;
+  }
+
+  @Provides()
+  suffix(noopDep: string) {
+    return `Suffix${noopDep}`;
+  }
+
+  @Provides()
+  noopDep(): string {
+    return '';
+  }
+}


### PR DESCRIPTION
The circular dependencies detector is reused for all dependencies. It needs to be reset after a dependency is resolved successfully, otherwise the second dependency that's resolved from the graph is flagged incorrectly as circular.