### PR TITLE
Throw if attempting to access undefined props in lifecycle bound graphs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -89,7 +89,8 @@
 		  "unused-imports/no-unused-vars": [
 			  "error",
 			  { "vars": "all", "varsIgnorePattern": "^_", "args": "after-used", "argsIgnorePattern": "^_" }
-		  ]
+		  ],
+      "@typescript-eslint/ban-ts-comment": "off"
     },
     "settings": {
       "import/resolver": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "cSpell.words": [
+    "Middlewares",
     "unmagler"
   ]
 }

--- a/src/Obsidian.ts
+++ b/src/Obsidian.ts
@@ -1,13 +1,13 @@
 import graphRegistry from './graph/registry/GraphRegistry';
 import { ObjectGraph } from './graph/ObjectGraph';
-import { Constructable, GraphInternals, ServiceLocator } from './types';
+import { GraphInternals, ServiceLocator } from './types';
 import { GraphMiddleware } from './graph/registry/GraphMiddleware';
 import lateInjector from './injectors/class/LateInjector';
 import serviceLocatorFactory from './graph/ServiceLocatorFactory';
 
 export default class Obsidian {
-  obtain<T extends ObjectGraph<P>, P = any>(
-    Graph: Constructable<T>,
+  obtain<T extends ObjectGraph<P>, P>(
+    Graph: new(...args: P[]) => T,
     props?: P,
   ): ServiceLocator<Omit<T, GraphInternals>> {
     return serviceLocatorFactory.fromGraph(Graph, props);

--- a/src/graph/registry/GraphRegistry.ts
+++ b/src/graph/registry/GraphRegistry.ts
@@ -2,6 +2,7 @@ import { Constructable } from '../../types';
 import { Graph } from '../Graph';
 import { Middleware } from './Middleware';
 import GraphMiddlewareChain from './GraphMiddlewareChain';
+import { NullProps as createNullProps } from './NullProps';
 
 export class GraphRegistry {
   private readonly constructorToInstance = new Map<Constructable<Graph>, Set<Graph>>();
@@ -33,9 +34,16 @@ export class GraphRegistry {
     if ((this.isSingleton(Graph) || this.isBoundToReactLifecycle(Graph)) && this.has(Graph)) {
       return this.getFirst(Graph);
     }
-    const graph = this.graphMiddlewares.resolve(Graph, props);
+    const graph = this.graphMiddlewares.resolve(Graph, this.ensurePropsIfLifecycleBoundGraph(Graph, props));
     this.set(Graph, graph);
     return graph as T;
+  }
+
+  private ensurePropsIfLifecycleBoundGraph<T extends Graph>(Graph: Constructable<T>, props?: any): any {
+    if (this.isBoundToReactLifecycle(Graph)) {
+      return props ?? createNullProps(Graph);
+    }
+    return props;
   }
 
   private has(Graph: Constructable<Graph>): boolean {

--- a/src/graph/registry/NullProps.ts
+++ b/src/graph/registry/NullProps.ts
@@ -1,0 +1,23 @@
+import type { Constructable } from '../../types';
+import { isDev } from '../../utils/isDev';
+import type { Graph } from '../Graph';
+
+export function NullProps(Graph: Constructable<Graph>) {
+  return new Proxy({}, new NullPropsProxyHandler(Graph));
+}
+
+class NullPropsProxyHandler implements ProxyHandler<{}> {
+  constructor(private graph: Constructable<Graph>) {}
+
+  get(target: object, property: string, receiver: any) {
+    if (property in target) return Reflect.get(target, property, receiver);
+    throw new Error(this.createErrorMessage(this.graph, property));
+  }
+
+  private createErrorMessage(graph: Constructable<Graph>, property: string) {
+    const graphName = isDev() ? graph.name : '';
+    return `Tried to get prop ${property} in a @LifecycleBound graph ${graphName}, but props were undefined. `
+    + `If you're using Obsidian.obtain(${graphName}) - then you should pass props to it explicitly: `
+    + `Obsidian.obtain(${graphName}, { ${property}: 'value' });`;
+  }
+}

--- a/src/injectors/hooks/HookInjector.test.ts
+++ b/src/injectors/hooks/HookInjector.test.ts
@@ -60,6 +60,6 @@ const hookB = ({ stringProvider }: { stringProvider: StringProvider }): Hook => 
   return { text };
 };
 
-const hookC = ({ computedFromProps }: DependenciesOf<LifecycleBoundGraph>): Hook => {
+const hookC = ({ computedFromProps }: DependenciesOf<LifecycleBoundGraph, 'computedFromProps'>): Hook => {
   return { text: computedFromProps };
 };

--- a/src/utils/isDev.ts
+++ b/src/utils/isDev.ts
@@ -1,0 +1,12 @@
+export function isDev(): boolean {
+  return isNodeDev() || isReactNativeDev();
+}
+
+function isNodeDev(): boolean {
+  return ['test', 'development'].includes(process.env['NODE_ENV'] ?? '');
+}
+
+function isReactNativeDev(): boolean {
+  // @ts-ignore
+  return __DEV__ as boolean ?? false;
+}

--- a/test/fixtures/LifecycleBoundGraph.ts
+++ b/test/fixtures/LifecycleBoundGraph.ts
@@ -4,11 +4,11 @@ import { LifecycleBound } from '../../src/decorators/LifecycleBound';
 export type Props = Record<string, any> & { stringFromProps: string };
 
 @LifecycleBound() @Graph()
-export class LifecycleBoundGraph<P = {}> extends ObjectGraph<P & Props> {
+export class LifecycleBoundGraph extends ObjectGraph<Props> {
   static timesCreated = 0;
-  private props: P & Props;
+  private props: Props;
 
-  constructor(props: P & Props) {
+  constructor(props: Props) {
     super(props);
     this.props = props;
     LifecycleBoundGraph.timesCreated++;
@@ -19,5 +19,10 @@ export class LifecycleBoundGraph<P = {}> extends ObjectGraph<P & Props> {
     return this.props.stringFromProps
       ? `A string passed via props: ${this.props.stringFromProps}`
       : 'stringFromProps does not exist';
+  }
+
+  @Provides()
+  doesNotRequireProps(): string {
+    return 'A string that does not require props';
   }
 }

--- a/test/integration/lifecyleBoundGraphs.test.tsx
+++ b/test/integration/lifecyleBoundGraphs.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {
   Inject,
   Injectable,
+  Obsidian,
   injectComponent,
   injectHook,
 } from '../../src';
@@ -32,6 +33,19 @@ describe('React lifecycle bound graphs', () => {
   it('passes props to the component', () => {
     const { container } = render(<ClassComponent stringFromProps='Obsidian is cool' />);
     expect(container.textContent).toBe('A string passed via props: Obsidian is cool');
+  });
+
+  it('requires passing props when used as a service locator', () => {
+    expect(() => Obsidian.obtain(LifecycleBoundGraph).computedFromProps()).toThrowError(
+      `Tried to get prop stringFromProps in a @LifecycleBound graph LifecycleBoundGraph, `
+      + `but props were undefined. If you're using Obsidian.obtain(LifecycleBoundGraph) - then you `
+      + `should pass props to it explicitly: Obsidian.obtain(LifecycleBoundGraph, { stringFromProps: 'value' });`,
+    );
+  });
+
+  it(`resolves a dependency that doesn't require props, even if props were not passed`, () => {
+    const dependency = Obsidian.obtain(LifecycleBoundGraph).doesNotRequireProps();
+    expect(dependency).toBe('A string that does not require props');
   });
 
   function createFunctionalComponent() {


### PR DESCRIPTION
Lifecycle bound graphs typically rely on the props of the initial component or hook that created them. When a lifecycle-bound graph is created as a result of calling `Obsidian.obtain()`, users tend not to pass props. This can cause unexpected errors as the graph requires the props.

This PR ensures an informative exception is thrown when attempting to access undefined props.