### PR TITLE
Implement mockModel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,3 +28,4 @@ export { OnNext, Unsubscribe } from './observable/types';
 export { Model } from './model/Model';
 
 export { testKit } from '../testkit';
+export { mockModel, mockGraphs } from '../testkit/index';

--- a/testkit/index.ts
+++ b/testkit/index.ts
@@ -1,22 +1,19 @@
-import { GraphResolveChain } from '../src/graph/registry/GraphResolveChain';
-import { isGraph, ObjectGraph } from '../src/graph/ObjectGraph';
-import { GraphMiddleware } from '../src/graph/registry/GraphMiddleware';
+import { ObjectGraph } from '../src/graph/ObjectGraph';
 import { Constructable } from '../src/types';
-import graphRegistry from '../src/graph/registry/GraphRegistry';
+import { mockGraphs } from './mockGraphs';
 
 class TestKit {
+  /**
+   * @deprecated testKit.mockGraphs is deprecated, use mockGraphs instead
+   */
   public mockGraphs(graphNameToGraph: Record<string, Constructable<ObjectGraph> | ((props: any) => ObjectGraph)>) {
-    const graphMiddleware = new class extends GraphMiddleware {
-      resolve<Props>(resolveChain: GraphResolveChain, Graph: Constructable<ObjectGraph>, props?: Props) {
-        if (graphNameToGraph[Graph.name]) {
-          const GraphOrGenerator = graphNameToGraph[Graph.name];
-          return isGraph(GraphOrGenerator) ? new GraphOrGenerator(props) : GraphOrGenerator(props);
-        }
-        return resolveChain.proceed(Graph, props);
-      }
-    }();
-    graphRegistry.addGraphMiddleware(graphMiddleware);
+    // eslint-disable-next-line no-console
+    console.warn('testKit.mockGraphs is deprecated, use mockGraphs instead');
+    return mockGraphs(graphNameToGraph);
   }
 }
+
+export { mockModel } from './mockModel';
+export { mockGraphs };
 
 export const testKit = new TestKit();

--- a/testkit/mockGraphs.ts
+++ b/testkit/mockGraphs.ts
@@ -1,0 +1,20 @@
+import { GraphResolveChain } from '../src/graph/registry/GraphResolveChain';
+import { isGraph, ObjectGraph } from '../src/graph/ObjectGraph';
+import { GraphMiddleware } from '../src/graph/registry/GraphMiddleware';
+import { Constructable } from '../src/types';
+import graphRegistry from '../src/graph/registry/GraphRegistry';
+
+export function mockGraphs(
+  graphNameToGraph: Record<string, Constructable<ObjectGraph> | ((props: any) => ObjectGraph)>,
+) {
+  const graphMiddleware = new class extends GraphMiddleware {
+    resolve<Props>(resolveChain: GraphResolveChain, Graph: Constructable<ObjectGraph>, props?: Props) {
+      if (graphNameToGraph[Graph.name]) {
+        const GraphOrGenerator = graphNameToGraph[Graph.name];
+        return isGraph(GraphOrGenerator) ? new GraphOrGenerator(props) : GraphOrGenerator(props);
+      }
+      return resolveChain.proceed(Graph, props);
+    }
+  }();
+  graphRegistry.addGraphMiddleware(graphMiddleware);
+}

--- a/testkit/mockModel.ts
+++ b/testkit/mockModel.ts
@@ -1,0 +1,10 @@
+import { Model } from '../src/model/Model';
+
+export function mockModel<T extends Model, S extends Partial<T>>(mock: S): T {
+  return new class extends Model {
+    constructor() {
+      super();
+      Object.assign(this, mock);
+    }
+  }() as T;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,8 @@
     "transformers/**/*",
     "test/**/*",
     "./clearGraphs.ts",
-    "global.d.ts"
+    "global.d.ts",
+    "testkit/**/*",
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This function is used to mock a model in unit tests.

### API
```ts
describe("statusViewModel", () => {
  let model: SomeModel;

  beforeEach(() => {
    model = mockModel({
      foo: new Observable("foo")
    });
  });

  ...
});
```