### PR TITLE
Support awaiting the current or next value of an observable

### DIFF
--- a/src/observable/Observable.ts
+++ b/src/observable/Observable.ts
@@ -18,6 +18,16 @@ export class Observable<T> implements IObservable<T> {
     this.subscribers.forEach((subscriber) => subscriber(value));
   }
 
+  async first(): Promise<T> {
+    if (this.currentValue) return this.currentValue;
+    return new Promise((resolve) => {
+      const unsubscribe = this.subscribe((value) => {
+        unsubscribe();
+        resolve(value);
+      });
+    });
+  }
+
   public subscribe(onNext: OnNext<T> = NOOP): Unsubscribe {
     if (this.subscribers.has(onNext)) {
       throw new Error('Subscriber already subscribed');

--- a/src/observable/observable.test.ts
+++ b/src/observable/observable.test.ts
@@ -73,4 +73,17 @@ describe('makeObservable', () => {
     const subscriber = () => { };
     expect(() => observable.unsubscribe(subscriber)).toThrowError(`Can't unsubscribe, subscriber doesn't exist`);
   });
+
+  it('should await the current value', async () => {
+    const observable = new Observable(123);
+    expect(await observable.first()).toBe(123);
+  });
+
+  it('should await the next value', async () => {
+    const observable = new Observable<number>();
+    const promise = observable.first();
+    observable.value = 123;
+    observable.value = 456;
+    expect(await promise).toBe(123);
+  });
 });


### PR DESCRIPTION
This PR adds a new API for awaiting the current or next value of an observable.

```ts
const obs = new Observable();
const currentOrNext = await obs.first();
```

Closes #113