### PR TITLE
Execute mediatorObservable.addSource callbacks immediately to create an initial value

### DIFF
--- a/src/observable/cold/ColdMediatorObservable.ts
+++ b/src/observable/cold/ColdMediatorObservable.ts
@@ -1,4 +1,6 @@
+import { Observable } from '../Observable';
 import { MediatorObservable } from '../mediator/MediatorObservable';
+import { OnNext } from '../types';
 
 export class ColdMediatorObservable<T extends object> extends MediatorObservable<T> {
   constructor(obj: T, private readonly handler = new PropertyAccessTrackingProxy<T>()) {
@@ -19,6 +21,11 @@ export class ColdMediatorObservable<T extends object> extends MediatorObservable
       super.value = { ...this.value, [key]: value };
       this.handler.resumeTracking();
     }
+  }
+
+  override addSource<S>(source: Observable<S>, onNext: OnNext<S>) {
+    source.subscribe(onNext);
+    return this;
   }
 }
 

--- a/src/observable/mediator/MediatorObservable.test.ts
+++ b/src/observable/mediator/MediatorObservable.test.ts
@@ -3,7 +3,7 @@ import { MediatorObservable } from './MediatorObservable';
 
 const NOOP = () => {};
 
-describe('ObservableMediator', () => {
+describe('MediatorObservable', () => {
   let uut!: MediatorObservable<number>;
 
   beforeEach(() => {

--- a/src/observable/mediator/MediatorObservable.test.ts
+++ b/src/observable/mediator/MediatorObservable.test.ts
@@ -130,4 +130,13 @@ describe('MediatorObservable', () => {
     a.value = 3;
     expect(uut.value).toEqual(6);
   });
+
+  it('should execute addSource callbacks immediately to create an initial value', () => {
+    const a = new Observable(1);
+    uut.addSource(a, (nextA) => {
+      uut.value = nextA * 2;
+    });
+
+    expect(uut.value).toEqual(2);
+  });
 });

--- a/src/observable/mediator/MediatorObservable.ts
+++ b/src/observable/mediator/MediatorObservable.ts
@@ -4,6 +4,9 @@ import { OnNext } from '../types';
 export class MediatorObservable<T> extends Observable<T> {
   addSource<S>(source: Observable<S>, onNext: OnNext<S>) {
     source.subscribe(onNext);
+    if (source.value !== undefined) {
+      onNext(source.value);
+    }
     return this;
   }
 }


### PR DESCRIPTION
MediatorObservable relies on other observables to produce a data stream. It's used to either merge two observables into a new observable or to "map" a single observable into a new kind. For these reasons, MediatorObservables should always have an initial value that's based on the mediated observables.

The current method of providing an initial value causes code duplication since it requires the developer to execute the logic contained in the `onChange` callbacks.

This PR change MediatorObservable so it executes the `onNext` callback immediately when `addSource` is invoked. This will effectively create the initial value, without needing to pass it explicitly in the constructor.