### PR TITLE
OnNext callbacks should never return a value

### DIFF
--- a/src/observable/types.ts
+++ b/src/observable/types.ts
@@ -1,4 +1,4 @@
-export type OnNext<T> = (value: T) => void;
+export type OnNext<T> = (value: T) => void | undefined; // OnNext callbacks should never return a value
 export type Unsubscribe = () => void;
 
 export interface Observable<T> {


### PR DESCRIPTION
Returning a value from an onNext callback usually indicates a developer error. Usually this happens when a developer wants to update the value of some mediatorObservable and mistakingly returned a value instead of assigning it.