### PR TITLE
Implement MediatorObservable.mapSource

### DIFF
--- a/src/observable/mediator/MediatorObservable.test.ts
+++ b/src/observable/mediator/MediatorObservable.test.ts
@@ -139,4 +139,31 @@ describe('MediatorObservable', () => {
 
     expect(uut.value).toEqual(2);
   });
+
+  it('should support mapping other observables', () => {
+    const o = new Observable(3);
+    const uut2 = new MediatorObservable()
+      .mapSource(o, (next) => {
+        return next * 2;
+      });
+    expect(uut2.value).toEqual(6);
+  });
+
+  it('should support mapping other observables with an initial value', () => {
+    const o = new Observable(3);
+    const uut2 = new MediatorObservable(5)
+      .mapSource(o, (next, currentValue) => {
+        return next * currentValue;
+      });
+    expect(uut2.value).toEqual(15);
+  });
+
+  it('should support mapping multiple observables', () => {
+    const a = new Observable(2);
+    const b = new Observable(3);
+    const uut2 = new MediatorObservable(5)
+      .mapSource(a, (next, currentValue) => next * currentValue)
+      .mapSource(b, (next, currentValue) => next * currentValue);
+    expect(uut2.value).toEqual(30);
+  });
 });

--- a/src/observable/mediator/MediatorObservable.ts
+++ b/src/observable/mediator/MediatorObservable.ts
@@ -1,7 +1,15 @@
 import { Observable } from '../Observable';
-import { OnNext } from '../types';
+import { Mapper, OnNext } from '../types';
 
 export class MediatorObservable<T> extends Observable<T> {
+  mapSource<Source, Result extends T>(source: Observable<Source>, mapNext: Mapper<Source, Result>) {
+    this.addSource<Source>(source, (next) => {
+      const mapped = mapNext(next, this.value as Result) as Result;
+      this.value = mapped;
+    });
+    return this;
+  }
+
   addSource<S>(source: Observable<S>, onNext: OnNext<S>) {
     source.subscribe(onNext);
     if (source.value !== undefined) {

--- a/src/observable/types.ts
+++ b/src/observable/types.ts
@@ -1,4 +1,7 @@
 export type OnNext<T> = (value: T) => void | undefined; // OnNext callbacks should never return a value
+export type Mapper<Other, Mine> = (next: Other, currentValue: Mine) => Mine extends void ?
+  'A map function must return a value. Check your map function and ensure it has a valid return statement.' :
+  Mine;
 export type Unsubscribe = () => void;
 
 export interface Observable<T> {


### PR DESCRIPTION
This PR adds a new API to the `MediatorObservable` class - `mapSource`. The new API lets developers map values from sources to the current value of the Mediator Observable. This also lets you instantiate a Mediator Observable and chain calls to `mapSource` while still relying on the value of the Mediator Observable.

Closes #118 