### PR TITLE
Fix leaking @LifecycleBound graphs used to inject class components

### DIFF
--- a/src/injectors/class/ClassInjector.ts
+++ b/src/injectors/class/ClassInjector.ts
@@ -3,6 +3,7 @@ import { GraphRegistry } from '../../graph/registry/GraphRegistry';
 import { Graph } from '../../graph/Graph';
 import InjectionMetadata from './InjectionMetadata';
 import { GRAPH_INSTANCE_NAME_KEY } from './LateInjector';
+import referenceCounter from '../../ReferenceCounter';
 
 export default class ClassInjector {
   constructor(
@@ -24,11 +25,17 @@ export default class ClassInjector {
     return new class Handler implements ProxyHandler<any> {
       construct(target: any, args: any[], newTarget: Function): any {
         const graph = graphRegistry.resolve(Graph, 'lifecycleOwner', args.length > 0 ? args[0] : undefined);
+        referenceCounter.retain(graph);
         Reflect.defineMetadata(GRAPH_INSTANCE_NAME_KEY, graph.name, target);
         const argsToInject = this.injectConstructorArgs(args, graph, target);
         graph.onBind(target);
         const createdObject = Reflect.construct(target, argsToInject, newTarget);
         this.injectProperties(target, createdObject, graph);
+        const originalComponentWillUnmount = createdObject.componentWillUnmount;
+        createdObject.componentWillUnmount = () => {
+          originalComponentWillUnmount?.();
+          referenceCounter.release(graph, (g) => graphRegistry.clear(g));
+        };
         return createdObject;
       }
 

--- a/test/integration/lifecyleBoundGraphs.test.tsx
+++ b/test/integration/lifecyleBoundGraphs.test.tsx
@@ -56,6 +56,14 @@ describe('React lifecycle bound graphs', () => {
     expect(LifecycleBoundGraph.timesCreated).toBe(1);
   });
 
+  it('clears a bound graph when all dependent class components are unmounted', () => {
+    const { unmount } = render(<ClassComponent stringFromProps='foo'/>);
+    unmount();
+    render(<Component />);
+
+    expect(LifecycleBoundGraph.timesCreated).toBe(2);
+  });
+
   function createFunctionalComponent() {
     const useHook = injectHook(() => {}, LifecycleBoundGraph);
 


### PR DESCRIPTION
@LifecycleBound graphs used to inject class components were not properly retained. 