### PR TITLE
Add ability to map multiple observables in a single callback

### DIFF
--- a/src/observable/mediator/MediatorObservable.test.ts
+++ b/src/observable/mediator/MediatorObservable.test.ts
@@ -164,4 +164,38 @@ describe('MediatorObservable', () => {
       .mapSource(b, (next, currentValue) => next * currentValue);
     expect(uut2.value).toEqual(30);
   });
+
+  it('should support observing multiple observables', () => {
+    const a = new Observable(true);
+    const b = new Observable(3);
+    const c = new Observable('bar');
+
+    const uut2 = new MediatorObservable('foo')
+      .mapSources([a, b, c], ([nextA, nextB, nextC], currentValue) => {
+        return `${currentValue} ${nextA.toString().repeat(nextB)} ${nextC}`;
+      });
+
+    expect(uut2.value).toEqual('foo truetruetrue bar');
+  });
+
+  it('should call the mapSources callback only once on initialization', () => {
+    const a = new Observable(1);
+    const b = new Observable(2);
+    const mapFn = jest.fn();
+
+    uut.mapSources([a, b], mapFn);
+
+    expect(mapFn).toHaveBeenCalledOnce();
+  });
+
+  it('should call the mapSources callback when a source updates', () => {
+    const a = new Observable(1);
+    const b = new Observable(2);
+    const mapFn = jest.fn();
+
+    uut.mapSources([a, b], mapFn);
+    a.value = 2;
+
+    expect(mapFn).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/observable/mediator/MediatorObservable.ts
+++ b/src/observable/mediator/MediatorObservable.ts
@@ -1,5 +1,12 @@
 import { Observable } from '../Observable';
-import { Mapper, OnNext } from '../types';
+import {
+  Mapper,
+  MultiMapper,
+  Observables,
+  OnNext,
+  Observable as IObservable,
+  Args,
+} from '../types';
 
 export class MediatorObservable<T> extends Observable<T> {
   mapSource<Source, Result extends T>(source: Observable<Source>, mapNext: Mapper<Source, Result>) {
@@ -10,11 +17,37 @@ export class MediatorObservable<T> extends Observable<T> {
     return this;
   }
 
-  addSource<S>(source: Observable<S>, onNext: OnNext<S>) {
+  addSource<S>(source: IObservable<S>, onNext: OnNext<S>) {
     source.subscribe(onNext);
     if (source.value !== undefined) {
       onNext(source.value);
     }
+    return this;
+  }
+
+  mapSources<S1, S2, S3, S4, S5>(
+    sources: Observables<S1, S2, S3, S4, S5>,
+    mapNext: MultiMapper<T, S1, S2, S3, S4, S5>,
+  ) {
+    const values = new Array(sources.length).fill(undefined) as Args<S1, S2, S3, S4, S5>;
+
+    sources
+      .filter((source) => source !== undefined)
+      .forEach((source, index) => {
+        this.addSource(source as IObservable<any>, (next) => {
+          if (values[index] === undefined) {
+            values[index] = next;
+          } else {
+            const mapped = mapNext(
+              values.map((value, i) => (i === index ? next : value)) as Args<S1, S2, S3, S4, S5>,
+              this.value,
+            ) as T;
+            this.value = mapped;
+          }
+        });
+      });
+
+    this.value = mapNext(values, this.value);
     return this;
   }
 }

--- a/src/observable/types.ts
+++ b/src/observable/types.ts
@@ -1,4 +1,5 @@
 export type OnNext<T> = (value: T) => void | undefined; // OnNext callbacks should never return a value
+
 export type Mapper<Other, Mine> = (next: Other, currentValue: Mine) => Mine extends void ?
   'A map function must return a value. Check your map function and ensure it has a valid return statement.' :
   Mine;
@@ -10,3 +11,20 @@ export interface Observable<T> {
 }
 
 export type ObservedValues<T> = { [K in keyof T]: T[K] extends Observable<infer R> ? R : never };
+
+export type MultiMapper<Mine, S1, S2, S3, S4, S5> = (
+  [S1, S2, S3, S4, S5]: Args<S1, S2, S3, S4, S5>,
+  currentValue: Mine,
+) => Mine;
+
+export type Observables<S1, S2, S3, S4, S5> =
+  [Observable<S1>, Observable<S2>] |
+  [Observable<S1>, Observable<S2>, Observable<S3>] |
+  [Observable<S1>, Observable<S2>, Observable<S3>, Observable<S4>] |
+  [Observable<S1>, Observable<S2>, Observable<S3>, Observable<S4>, Observable<S5>];
+
+export type Args<A1, A2, A3, A4, A5> =
+  [A1, A2] |
+  [A1, A2, A3] |
+  [A1, A2, A3, A4] |
+  [A1, A2, A3, A4, A5];


### PR DESCRIPTION
A common case with MediatorObservables is the need to create a side effect based on multiple Observables. The mapSource function maps a single source. When it's used to map multiple sources, in order to adhere to the DRY principle we won't be able to inline to onNext callback as it needs to be shared in multiple calls to mapSource.

This PR adds the mapSources function which receives multiple sources and consequently makes it easier to share the same callback.