### PR TITLE
Throw exception on undefined graph

### DIFF
--- a/src/injectors/components/InjectComponent.test.tsx
+++ b/src/injectors/components/InjectComponent.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
+import type { Constructable, ObjectGraph } from 'src';
 import MainGraph, { Dependencies } from '../../../test/fixtures/MainGraph';
 import { injectComponent } from './InjectComponent';
 
@@ -32,5 +33,16 @@ describe('injectComponent', () => {
     const InjectedComponent = injectComponent(component, MainGraph);
     const { container } = render(<InjectedComponent />);
     expect(container.textContent).toBe('error: own prop not provided - Fear kills progress');
+  });
+
+  // it throws an error if the Graph is undefined
+  it('Throws an error if the Graph is undefined', () => {
+    const Graph = undefined as unknown as Constructable<ObjectGraph>;
+    expect(() => injectComponent(component, Graph)).toThrowError(
+      `injectComponent was called with an undefined Graph.`
+      + `This is probably not an issue with Obsidian.`
+      + `It's typically caused by circular dependencies.`
+      + ` Check the implementation of component.`,
+    );
   });
 });

--- a/src/injectors/components/InjectComponent.ts
+++ b/src/injectors/components/InjectComponent.ts
@@ -2,20 +2,20 @@ import { ObjectGraph } from '../../graph/ObjectGraph';
 import { Constructable } from '../../types';
 import ComponentInjector from './ComponentInjector';
 
-interface Descriminator {
-  obsidianDescriminator: never;
+interface Discriminator {
+  obsidianDiscriminator: never;
 }
 
 const componentInjector = new ComponentInjector();
 
-export const injectComponent = <OwnProps = Descriminator, InjectedProps = Descriminator> (
+export const injectComponent = <OwnProps = Discriminator, InjectedProps = Discriminator> (
   Target: React.FunctionComponent<
-  (OwnProps extends infer P ? OwnProps extends Descriminator ? P : OwnProps : never) &
-  (InjectedProps extends Descriminator ? any : InjectedProps)
+  (OwnProps extends infer P ? OwnProps extends Discriminator ? P : OwnProps : never) &
+  (InjectedProps extends Discriminator ? any : InjectedProps)
   >,
   Graph: Constructable<ObjectGraph>,
 ) => componentInjector.inject(Target, Graph) as React.FunctionComponent<
-  InjectedProps extends Descriminator ?
-    OwnProps extends Descriminator ? Partial<OwnProps> : OwnProps :
+  InjectedProps extends Discriminator ?
+    OwnProps extends Discriminator ? Partial<OwnProps> : OwnProps :
     OwnProps extends InjectedProps ? Partial<OwnProps> : OwnProps & Partial<InjectedProps>
   >;

--- a/src/injectors/components/InjectComponent.ts
+++ b/src/injectors/components/InjectComponent.ts
@@ -14,8 +14,22 @@ export const injectComponent = <OwnProps = Discriminator, InjectedProps = Discri
   (InjectedProps extends Discriminator ? any : InjectedProps)
   >,
   Graph: Constructable<ObjectGraph>,
-) => componentInjector.inject(Target, Graph) as React.FunctionComponent<
+) => {
+  assertGraph(Graph, Target);
+
+  return componentInjector.inject(Target, Graph) as React.FunctionComponent<
   InjectedProps extends Discriminator ?
     OwnProps extends Discriminator ? Partial<OwnProps> : OwnProps :
     OwnProps extends InjectedProps ? Partial<OwnProps> : OwnProps & Partial<InjectedProps>
   >;
+};
+function assertGraph(Graph: Constructable<ObjectGraph<unknown>>, Target: any) {
+  if (!Graph) {
+    throw new Error(
+      `injectComponent was called with an undefined Graph.`
+      + `This is probably not an issue with Obsidian.`
+      + `It's typically caused by circular dependencies.`
+      + ` Check the implementation of ${Target.name}.`,
+    );
+  }
+}


### PR DESCRIPTION
Throw if injectComponent was called with an undefined graph. This could happen due to circular dependencies that prevent the Graph from being resolved.