### PR TITLE
Fix leaking graphs when classes are injected by lifecycle bound graphs

### DIFF
--- a/packages/react-obsidian/src/graph/registry/GraphRegistry.ts
+++ b/packages/react-obsidian/src/graph/registry/GraphRegistry.ts
@@ -32,13 +32,13 @@ export class GraphRegistry {
 
   resolve<T extends Graph>(
     Graph: Constructable<T>,
-    source: 'lifecycleOwner' | 'serviceLocator' = 'lifecycleOwner',
+    source: 'lifecycleOwner' | 'classInjection' | 'serviceLocator' = 'lifecycleOwner',
     props: any = undefined,
   ): T {
     if ((this.isSingleton(Graph) || this.isBoundToReactLifecycle(Graph)) && this.has(Graph)) {
       return this.getFirst(Graph);
     }
-    if (this.isBoundToReactLifecycle(Graph) && source === 'serviceLocator') {
+    if (this.isBoundToReactLifecycle(Graph) && source !== 'lifecycleOwner') {
       throw new ObtainLifecycleBoundGraphException(Graph);
     }
     const graph = this.graphMiddlewares.resolve(Graph, props);

--- a/packages/react-obsidian/src/injectors/class/ClassInjector.ts
+++ b/packages/react-obsidian/src/injectors/class/ClassInjector.ts
@@ -24,8 +24,12 @@ export default class ClassInjector {
   ): ProxyHandler<any> {
     return new class Handler implements ProxyHandler<any> {
       construct(target: any, args: any[], newTarget: Function): any {
-        const graph = graphRegistry.resolve(Graph, 'lifecycleOwner', args.length > 0 ? args[0] : undefined);
-        referenceCounter.retain(graph);
+        const isReactClassComponent = target.prototype?.isReactComponent;
+        const source = isReactClassComponent ? 'lifecycleOwner' : 'classInjection';
+        const graph = graphRegistry.resolve(Graph, source, args.length > 0 ? args[0] : undefined);
+        if (isReactClassComponent) {
+          referenceCounter.retain(graph);
+        }
         Reflect.defineMetadata(GRAPH_INSTANCE_NAME_KEY, graph.name, target);
         const argsToInject = this.injectConstructorArgs(args, graph, target);
         graph.onBind(target);


### PR DESCRIPTION
When a React construct component is injected by a lifecycle bound graph, the graph is retained in memory until the React construct is unmounted.

Injecting regular classes also contributed to the retention count which caused a bug as graphs are released on unmount.

This commit retains graphs only if the injection target is a React class component.