### PR TITLE
Refactor ESLint rule

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,11 @@
 {
   "cSpell.words": [
     "estree",
-    "TSES",
-    "unmagler",
     "Middlewares",
     "MVVM",
     "preconfigured",
+    "TSES",
+    "unimported",
     "unmagler",
     "unsubscribers"
   ],

--- a/packages/eslint-plugin-obsidian/.eslintrc.json
+++ b/packages/eslint-plugin-obsidian/.eslintrc.json
@@ -24,6 +24,7 @@
   ],
   "rules": {
     "no-console":"off",
+    "no-empty-function": ["error", { "allow": ["constructors"] }],
     "no-multi-spaces": "error",
     "no-multiple-empty-lines": ["error", { "max": 1 }],
     "@stylistic/max-len": [

--- a/packages/eslint-plugin-obsidian/rules/dto/classDeclaration.ts
+++ b/packages/eslint-plugin-obsidian/rules/dto/classDeclaration.ts
@@ -1,0 +1,22 @@
+import type { TSESTree } from '@typescript-eslint/types';
+import { Decorator } from './decorator';
+
+export class ClassDeclaration {
+  constructor(public node: TSESTree.ClassDeclaration) {}
+
+  get decoratorNames() {
+    return this.decorators.map((decorator: Decorator) => {
+      return decorator.expression.callee.name;
+    }) || [];
+  }
+
+  get decorators() {
+    return this.node.decorators.map((decorator: TSESTree.Decorator) => {
+      return new Decorator(decorator);
+    });
+  }
+
+  get body() {
+    return this.node.body.body;
+  }
+}

--- a/packages/eslint-plugin-obsidian/rules/dto/decorator.ts
+++ b/packages/eslint-plugin-obsidian/rules/dto/decorator.ts
@@ -1,0 +1,13 @@
+import type { TSESTree } from '@typescript-eslint/types';
+
+interface CallExpression extends TSESTree.CallExpression {
+  callee: TSESTree.Identifier;
+}
+
+export class Decorator {
+  constructor(private node: TSESTree.Decorator) {}
+
+  get expression() {
+    return this.node.expression as CallExpression;
+  }
+}

--- a/packages/eslint-plugin-obsidian/rules/dto/file.ts
+++ b/packages/eslint-plugin-obsidian/rules/dto/file.ts
@@ -1,0 +1,22 @@
+import type { TSESTree } from '@typescript-eslint/types';
+
+export class File {
+  constructor(private program: TSESTree.Program) { }
+
+  public findGraph(name: string) {
+    return this.classNodes.find((node) => {
+      console.log((node as TSESTree.ClassDeclaration).id?.name);
+      return node.id?.name === name;
+    });
+  }
+
+  private get classNodes() {
+    return this.body.filter((node) => {
+      return node.type === 'ClassDeclaration';
+    }) as TSESTree.ClassDeclaration[];
+  }
+
+  private get body() {
+    return this.program.body;
+  }
+}

--- a/packages/eslint-plugin-obsidian/rules/dto/file.ts
+++ b/packages/eslint-plugin-obsidian/rules/dto/file.ts
@@ -5,7 +5,6 @@ export class File {
 
   public findGraph(name: string) {
     return this.classNodes.find((node) => {
-      console.log((node as TSESTree.ClassDeclaration).id?.name);
       return node.id?.name === name;
     });
   }

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/ASTFunctions.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/ASTFunctions.ts
@@ -38,7 +38,6 @@ export function getDependenciesFromSubgraphs(
 ) {
   const paths: {path: string; import: string}[] = [];
   const dependencies: string[] = [];
-
   imports.forEach((el) => {
     el.specifiers.forEach((specifier) => {
       if (subGraphs.includes(specifier.local.name)) {

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/createRule.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/createRule.ts
@@ -1,49 +1,19 @@
-import type { RuleContext } from '@typescript-eslint/utils/ts-eslint';
 import type { TSESTree } from '@typescript-eslint/types';
-import {
-  getSubGraphs,
-  getDependenciesFromSubgraphs,
-  mapFunctions,
-  checkDependencies,
-  getDecoratorName,
-  getPropertyDeclarations,
-} from './ASTFunctions';
 import type { PathResolver } from '../framework/pathResolver';
+import { ClassDeclaration } from '../dto/classDeclaration';
+import type { Context } from './types';
+import { GraphHandler } from './graphHandler';
 
-export function create(
-  context: RuleContext<'unresolved-provider-dependencies', []>,
-  pathResolver: PathResolver,
-) {
-  const imports:TSESTree.ImportDeclaration[] = [];
-  const dependencies:string[] = [];
+export function create(context: Context,pathResolver: PathResolver) {
+  const imports: TSESTree.ImportDeclaration[] = [];
+  const graphHandler = new GraphHandler(context, pathResolver, imports);
 
   return {
     ImportDeclaration(node: TSESTree.ImportDeclaration) {
       imports.push(node);
     },
     ClassDeclaration(node: TSESTree.ClassDeclaration) {
-      const { decorators } = node;
-      if (decorators) {
-        const decoratorNames = decorators.map((decorator: TSESTree.Decorator) => getDecoratorName(decorator));
-        if (decoratorNames.includes('Graph')) {
-          const subGraphs = getSubGraphs(decorators);
-          if (subGraphs.length > 0) {
-            dependencies.push(...getDependenciesFromSubgraphs(imports, subGraphs, context, pathResolver));
-          }
-          dependencies.push(...mapFunctions(node));
-          dependencies.push(...getPropertyDeclarations(node));
-          const check = checkDependencies(node, dependencies);
-          if (!check?.value) {
-            context.report({
-              node,
-              messageId: 'unresolved-provider-dependencies',
-              data: {
-                dependencyName: check.param,
-              },
-            });
-          }
-        }
-      }
+      graphHandler.handle(new ClassDeclaration(node));
     },
   };
 }

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/errorReporter.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/errorReporter.ts
@@ -8,7 +8,6 @@ export function reportErrorIfDependencyIsUnresolved(
   if (error) {
     context.report({
       node: node!,
-      // node: clazz.node,
       messageId: 'unresolved-provider-dependencies',
       data: {
         dependencyName: param,

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/errorReporter.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/errorReporter.ts
@@ -1,0 +1,18 @@
+import type { TSESTree } from '@typescript-eslint/types';
+import type { Context } from './types';
+
+export function reportErrorIfDependencyIsUnresolved(
+  context: Context,
+  {error, param, node}: {error: boolean; param?: string; node?: TSESTree.Node},
+) {
+  if (error) {
+    context.report({
+      node: node!,
+      // node: clazz.node,
+      messageId: 'unresolved-provider-dependencies',
+      data: {
+        dependencyName: param,
+      },
+    });
+  }
+}

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/graphHandler.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/graphHandler.ts
@@ -32,7 +32,7 @@ export class GraphHandler {
   private resolveDependencies(clazz: ClassDeclaration) {
     const subGraphs = getSubGraphs(clazz);
     return [
-      ...getDependenciesFromSubgraphs(this.imports, subGraphs, this.context, this.pathResolver),
+      ...getDependenciesFromSubgraphs(clazz, this.imports, subGraphs, this.context, this.pathResolver),
       ...mapFunctions(clazz),
       ...getPropertyDeclarations(clazz),
     ];

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/graphHandler.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/graphHandler.ts
@@ -19,13 +19,14 @@ export class GraphHandler {
   ) { }
 
   public handle(clazz: ClassDeclaration) {
-    if (this.doesNotHaveGraphDecorator(clazz)) return;
-    const dependencies = this.resolveDependencies(clazz);
-    reportErrorIfDependencyIsUnresolved(this.context, checkDependencies(clazz, dependencies));
+    if (this.hasGraphDecorator(clazz)) {
+      const dependencies = this.resolveDependencies(clazz);
+      reportErrorIfDependencyIsUnresolved(this.context, checkDependencies(clazz, dependencies));
+    }
   }
 
-  private doesNotHaveGraphDecorator(clazz: ClassDeclaration) {
-    return clazz.decoratorNames.includes('Graph') === false;
+  private hasGraphDecorator(clazz: ClassDeclaration) {
+    return clazz.decoratorNames.includes('Graph');
   }
 
   private resolveDependencies(clazz: ClassDeclaration) {

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/graphHandler.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/graphHandler.ts
@@ -1,0 +1,39 @@
+import type { TSESTree } from '@typescript-eslint/types';
+import type { ClassDeclaration } from '../dto/classDeclaration';
+import type { PathResolver } from '../framework/pathResolver';
+import type { Context } from './types';
+import {
+  checkDependencies,
+  getDependenciesFromSubgraphs,
+  getPropertyDeclarations,
+  getSubGraphs,
+  mapFunctions,
+} from './ASTFunctions';
+import { reportErrorIfDependencyIsUnresolved } from './errorReporter';
+
+export class GraphHandler {
+  constructor(
+    private context: Context,
+    private pathResolver: PathResolver,
+    private imports: TSESTree.ImportDeclaration[],
+  ) { }
+
+  public handle(clazz: ClassDeclaration) {
+    if (this.doesNotHaveGraphDecorator(clazz)) return;
+    const dependencies = this.resolveDependencies(clazz);
+    reportErrorIfDependencyIsUnresolved(this.context, checkDependencies(clazz, dependencies));
+  }
+
+  private doesNotHaveGraphDecorator(clazz: ClassDeclaration) {
+    return clazz.decoratorNames.includes('Graph') === false;
+  }
+
+  private resolveDependencies(clazz: ClassDeclaration) {
+    const subGraphs = getSubGraphs(clazz);
+    return [
+      ...getDependenciesFromSubgraphs(this.imports, subGraphs, this.context, this.pathResolver),
+      ...mapFunctions(clazz),
+      ...getPropertyDeclarations(clazz),
+    ];
+  }
+}

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/types.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/types.ts
@@ -1,0 +1,3 @@
+import type { RuleContext } from '@typescript-eslint/utils/ts-eslint';
+
+export type Context = RuleContext<'unresolved-provider-dependencies', []>;

--- a/packages/eslint-plugin-obsidian/tests/stubs/PathResolverStub.ts
+++ b/packages/eslint-plugin-obsidian/tests/stubs/PathResolverStub.ts
@@ -1,5 +1,4 @@
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint';
-import path = require('path') ;
 import { PathResolver } from '../../rules/framework/pathResolver';
 
 export class PathResolverStub implements PathResolver {
@@ -7,8 +6,10 @@ export class PathResolverStub implements PathResolver {
     switch(relativeFilePath) {
       case './subgraph':
         return `${context.cwd}/tests/unresolvedProviderDependencies/fixtures/subgraph.ts`;
+      case './graphWithSubgraph':
+        return `${context.cwd}/tests/unresolvedProviderDependencies/fixtures/graphWithSubgraph.ts`;
       default:
-        return path.join(path.dirname(context.getFilename()), `${relativeFilePath}.ts`);
+        throw new Error(`PathResolverStub: Unhandled relativeFilePath: ${relativeFilePath}`);
     }
   }
 }

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/validGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/validGraphs.ts
@@ -1,4 +1,4 @@
-export const validGraphSimple = `import { uniqueId } from 'lodash';
+export const validGraph = `import { uniqueId } from 'lodash';
 import { Graph, ObjectGraph, Provides } from 'src';
 
 @Graph()

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/validGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/validGraphs.ts
@@ -40,3 +40,31 @@ export default class SimpleGraphWithSubgraph extends ObjectGraph {
     return instanceId;
   }
 }`;
+
+export const validFileWithTwoGraphs = `
+import {
+  Graph,
+  ObjectGraph,
+  Provides,
+}  from 'src';
+
+@Graph()
+class Subgraph extends ObjectGraph {
+  @Provides()
+  subgraphString(): string {
+    return 'from subgraph';
+  }
+
+  @Provides()
+  subgraphDescriminator(): string {
+    return 'lol';
+  }
+}
+
+@Graph({ subgraphs: [Subgraph] })
+class MainGraph extends ObjectGraph {
+  @Provides()
+  graphString(subgraphString: string): string {
+    return 'from main ' + subgraphString;
+  }
+}`;

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/unresolvedDependencies.test.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/unresolvedDependencies.test.ts
@@ -1,12 +1,12 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
+import { unresolvedProviderDependenciesGenerator } from '../../rules/unresolvedProviderDependencies';
+import { PathResolverStub } from '../stubs/PathResolverStub';
 import {
   validGraphSimple,
   validGraphWithSubgraph,
   validLifecycleBoundGraphWithSubgraph,
 } from './fixtures/validGraphs';
-import { unresolvedProviderDependenciesGenerator } from '../../rules/unresolvedProviderDependencies';
 import { invalidGraph } from './fixtures/invalidGraphs';
-import { PathResolverStub } from '../stubs/PathResolverStub';
 
 const ruleTester = new RuleTester();
 
@@ -14,7 +14,11 @@ ruleTester.run(
   'unresolved-provider-dependencies',
   unresolvedProviderDependenciesGenerator(new PathResolverStub()),
   {
-    valid: [validGraphSimple, validGraphWithSubgraph, validLifecycleBoundGraphWithSubgraph],
+    valid: [
+      validGraphSimple,
+      validGraphWithSubgraph,
+      validLifecycleBoundGraphWithSubgraph,
+    ],
     invalid: [
       {
         code: invalidGraph,

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/unresolvedDependencies.test.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/unresolvedDependencies.test.ts
@@ -3,7 +3,7 @@ import { unresolvedProviderDependenciesGenerator } from '../../rules/unresolvedP
 import { PathResolverStub } from '../stubs/PathResolverStub';
 import {
   validFileWithTwoGraphs,
-  validGraphSimple,
+  validGraph,
   validGraphWithSubgraph,
   validLifecycleBoundGraphWithSubgraph,
 } from './fixtures/validGraphs';
@@ -16,7 +16,7 @@ ruleTester.run(
   unresolvedProviderDependenciesGenerator(new PathResolverStub()),
   {
     valid: [
-      validGraphSimple,
+      validGraph,
       validGraphWithSubgraph,
       validLifecycleBoundGraphWithSubgraph,
       validFileWithTwoGraphs,

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/unresolvedDependencies.test.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/unresolvedDependencies.test.ts
@@ -2,6 +2,7 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import { unresolvedProviderDependenciesGenerator } from '../../rules/unresolvedProviderDependencies';
 import { PathResolverStub } from '../stubs/PathResolverStub';
 import {
+  validFileWithTwoGraphs,
   validGraphSimple,
   validGraphWithSubgraph,
   validLifecycleBoundGraphWithSubgraph,
@@ -18,6 +19,7 @@ ruleTester.run(
       validGraphSimple,
       validGraphWithSubgraph,
       validLifecycleBoundGraphWithSubgraph,
+      validFileWithTwoGraphs,
     ],
     invalid: [
       {


### PR DESCRIPTION
1. Break createRule.ts into separate classes and functions
2. Start using DTO's instead of passing raw AST nodes
3. Report the error on the unresolved dependency node instead of the entire graph