### PR TITLE
Resolve dependencies from nested subgraphs

### DIFF
--- a/packages/eslint-plugin-obsidian/rules/ast/utils.ts
+++ b/packages/eslint-plugin-obsidian/rules/ast/utils.ts
@@ -1,5 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import type { ArrayExpressionElement } from '../unresolvedProviderDependencies/types';
+import { assertDefined } from '../utils/assertions';
 
 export function isClassLike(node: TSESTree.Node): node is TSESTree.ClassDeclaration {
   switch (node.type) {
@@ -35,12 +36,13 @@ export function getClassDeclaration(node: TSESTree.Node): TSESTree.ClassDeclarat
   }
 }
 
-export function requireProgram(node: TSESTree.Node): TSESTree.Program {
+export function requireProgram(node: TSESTree.Node | undefined): TSESTree.Program {
+  assertDefined(node);
   switch (node.type) {
     case 'Program':
       return node;
     default:
-      return requireProgram(node.parent!);
+      return requireProgram(node.parent);
   }
 }
 

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/dependencyResolver.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/dependencyResolver.ts
@@ -17,8 +17,7 @@ export class DependencyResolver {
   private getDependenciesFromSubgraphs(clazz: ClassWithImports): string[] {
     return this.subgraphResolver
       .resolve(clazz)
-      .map(this.getGraphDependencies)
-      .flat();
+      .flatMap(this.getGraphDependencies);
   }
 
   private getGraphDependencies({ clazz }: ClassWithImports) {

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/graphWithSubgraph.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/graphWithSubgraph.ts
@@ -1,0 +1,10 @@
+import { Graph, ObjectGraph, Provides } from 'react-obsidian';
+import Subgraph from './subgraph';
+
+@Graph({subgraphs: [Subgraph]})
+export default class GraphWithSubgraph extends ObjectGraph {
+  @Provides()
+  someString(instanceId: string, foo: string): string {
+    return `foo${instanceId}${foo}`;
+  }
+}

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/subgraph.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/subgraph.ts
@@ -12,4 +12,9 @@ export default class Subgraph extends ObjectGraph {
   instanceId(): string {
     return uniqueId('graph');
   }
+
+  @Provides()
+  foo(): string {
+    return 'foo';
+  }
 }

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/validGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/validGraphs.ts
@@ -57,6 +57,22 @@ export default class SimpleGraphWithSubgraph extends ObjectGraph {
   }
 }`;
 
+export const validGraphWithNestedSubgraphs = `
+import {
+  Graph,
+  ObjectGraph,
+  Provides,
+}  from 'src';
+import GraphWithSubgraph from './graphWithSubgraph';
+
+@Graph({ subgraphs: [GraphWithSubgraph] })
+export default class GraphWithNestedSubgraphs extends ObjectGraph {
+  @Provides()
+  bar(foo: string): string {
+    return foo + 'bar';
+  }
+}`;
+
 export const validFileWithTwoGraphs = `
 import {
   Graph,

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/unresolvedDependencies.test.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/unresolvedDependencies.test.ts
@@ -5,6 +5,7 @@ import {
   validFileWithTwoGraphs,
   validGraph,
   validGraphWithNamedExportSubgraph,
+  validGraphWithNestedSubgraphs,
   validGraphWithRegularMethod,
   validGraphWithSubgraph,
   validLifecycleBoundGraphWithSubgraph,
@@ -24,6 +25,7 @@ ruleTester.run(
       validFileWithTwoGraphs,
       validGraphWithNamedExportSubgraph,
       validGraphWithRegularMethod,
+      validGraphWithNestedSubgraphs,
     ],
     invalid: [
       {


### PR DESCRIPTION
This PR introduces a small fix to the SubgraphResolver - subgraphs are resolved recursively. Until now we only resolved one level of subgraphs, meaning not all graphs were taken into account when resolving dependencies.