### PR TITLE
Fix file path resolving in ESLint rule

### DIFF
--- a/packages/eslint-plugin-obsidian/rules/dto/class.ts
+++ b/packages/eslint-plugin-obsidian/rules/dto/class.ts
@@ -16,7 +16,7 @@ export class Clazz {
   }
 
   get decorators() {
-    return this.node.decorators.map((decorator: TSESTree.Decorator) => {
+    return (this.node.decorators ?? []).map((decorator: TSESTree.Decorator) => {
       return new Decorator(decorator);
     });
   }

--- a/packages/eslint-plugin-obsidian/rules/dto/classWithImports.ts
+++ b/packages/eslint-plugin-obsidian/rules/dto/classWithImports.ts
@@ -6,5 +6,6 @@ export class ClassWithImports {
   constructor(
     public readonly clazz: Clazz,
     public readonly imports: Import[],
+    public readonly path: string,
   ) {}
 }

--- a/packages/eslint-plugin-obsidian/rules/dto/file.ts
+++ b/packages/eslint-plugin-obsidian/rules/dto/file.ts
@@ -6,7 +6,10 @@ import { ClassWithImports } from './classWithImports';
 import { assertDefined } from '../utils/assertions';
 
 export class File {
-  constructor(private program: TSESTree.Program) { }
+  constructor(
+    private program: TSESTree.Program,
+    private path: string,
+  ) { }
 
   public requireGraph(name: string) {
     const graph = this.classNodes.find((node) => {
@@ -28,7 +31,7 @@ export class File {
 
   public toClassWithImports() {
     return this.graphs.map((graph) => {
-      return new ClassWithImports(graph, this.imports);
+      return new ClassWithImports(graph, this.imports, this.path);
     });
   }
 

--- a/packages/eslint-plugin-obsidian/rules/dto/method.ts
+++ b/packages/eslint-plugin-obsidian/rules/dto/method.ts
@@ -21,7 +21,7 @@ export class Method {
   }
 
   private get decorators() {
-    return this.node.decorators.map((decorator) => {
+    return (this.node.decorators ?? []).map((decorator) => {
       return new Decorator(decorator);
     }) || [];
   }

--- a/packages/eslint-plugin-obsidian/rules/framework/fileReader.ts
+++ b/packages/eslint-plugin-obsidian/rules/framework/fileReader.ts
@@ -1,17 +1,16 @@
-import type { RuleContext } from '@typescript-eslint/utils/ts-eslint';
 import * as fs from 'fs';
 import { parse } from '@typescript-eslint/parser';
 import type { PathResolver } from './pathResolver';
 import { File } from '../dto/file';
 
 export class FileReader {
-  constructor(private context: RuleContext<any, any>, private pathResolver: PathResolver) {}
+  constructor(private pathResolver: PathResolver) { }
 
-  public read(relativeFilePath: string) {
-    const filePath = this.pathResolver.resolve(this.context, relativeFilePath);
+  public read(baseFilePath: string, relativeFilePath: string) {
+    const filePath = this.pathResolver.resolve(baseFilePath, relativeFilePath);
     const fileContent = fs.readFileSync(filePath, { encoding: 'utf8' });
     const fileAST = this.parse(fileContent, filePath);
-    return new File(fileAST);
+    return new File(fileAST, filePath);
   }
 
   private parse(content: string, filePath: string) {

--- a/packages/eslint-plugin-obsidian/rules/framework/pathResolver.ts
+++ b/packages/eslint-plugin-obsidian/rules/framework/pathResolver.ts
@@ -1,8 +1,7 @@
-import type { RuleContext } from '@typescript-eslint/utils/ts-eslint';
 import path = require('path') ;
 
 export class PathResolver {
-  public resolve(context: RuleContext<any, any>, relativeFilePath: string) {
-    return path.join(path.dirname(context.getFilename()), `${relativeFilePath}.ts`);
+  public resolve(baseFilePath: string, relativeFilePath: string) {
+    return path.resolve(path.dirname(baseFilePath), `${relativeFilePath}.ts`);
   }
 }

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/dependencyResolver.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/dependencyResolver.ts
@@ -2,12 +2,13 @@ import { ClassWithImports } from '../dto/classWithImports';
 import type { Import } from '../dto/import';
 import type { Clazz } from '../dto/class';
 import type { SubgraphResolver } from './subgraphResolver';
+import type { Context } from './types';
 
 export class DependencyResolver {
   constructor(private subgraphResolver: SubgraphResolver) { }
 
-  public resolve(clazz: Clazz, imports: Import[]) {
-    const classWithImports = new ClassWithImports(clazz, imports);
+  public resolve(context: Context, clazz: Clazz, imports: Import[]) {
+    const classWithImports = new ClassWithImports(clazz, imports, context.physicalFilename!);
     return [
       ...this.getGraphDependencies(classWithImports),
       ...this.getDependenciesFromSubgraphs(classWithImports),

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/graphHandler.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/graphHandler.ts
@@ -14,7 +14,7 @@ export class GraphHandler {
 
   public handle(clazz: Clazz, imports: Import[]) {
     if (this.hasGraphDecorator(clazz)) {
-      const dependencies = this.dependencyResolver.resolve(clazz, imports);
+      const dependencies = this.dependencyResolver.resolve(this.context, clazz, imports);
       const resolvedDependenciesCheck = this.resolvedDependencyChecker.check(clazz, dependencies);
       reportErrorIfDependencyIsUnresolved(this.context, resolvedDependenciesCheck);
     }

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/index.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/index.ts
@@ -15,7 +15,7 @@ export const unresolvedProviderDependenciesGenerator = (
 ) => {
   return createRule({
     create: (context: RuleContext<'unresolved-provider-dependencies', []>) => {
-      return create(context, new FileReader(context, pathResolver));
+      return create(context, new FileReader(pathResolver));
     },
     name: 'unresolved-provider-dependencies',
     meta: {

--- a/packages/eslint-plugin-obsidian/tests/stubs/PathResolverStub.ts
+++ b/packages/eslint-plugin-obsidian/tests/stubs/PathResolverStub.ts
@@ -1,15 +1,16 @@
-import type { RuleContext } from '@typescript-eslint/utils/ts-eslint';
 import { PathResolver } from '../../rules/framework/pathResolver';
 
 export class PathResolverStub implements PathResolver {
-  public resolve(context: RuleContext<any, any>, relativeFilePath: string): string {
+
+  public resolve(_baseFilePath: string, relativeFilePath: string): string {
+    const cwd = process.cwd();
     switch(relativeFilePath) {
       case './subgraph':
-        return `${context.cwd}/tests/unresolvedProviderDependencies/fixtures/subgraph.ts`;
+        return `${cwd}/tests/unresolvedProviderDependencies/fixtures/subgraph.ts`;
       case './graphWithSubgraph':
-        return `${context.cwd}/tests/unresolvedProviderDependencies/fixtures/graphWithSubgraph.ts`;
+        return `${cwd}/tests/unresolvedProviderDependencies/fixtures/graphWithSubgraph.ts`;
       case './namedExportSubgraph':
-        return `${context.cwd}/tests/unresolvedProviderDependencies/fixtures/namedExportSubgraph.ts`;
+        return `${cwd}/tests/unresolvedProviderDependencies/fixtures/namedExportSubgraph.ts`;
       default:
         throw new Error(`PathResolverStub: Unhandled relativeFilePath: ${relativeFilePath}`);
     }


### PR DESCRIPTION
The path of nested subgraphs wasn't resolved properly as it relayed on the path of the file being linted. This PR changes the logic slightly so the path is calculated based on the path of the initial graph being linted.

This PR also fixes a few NPE's found while linting an actual project. Apparently the types exported by TSESTree aren't 100% accurate.