### PR TITLE
Fix call to context.getPhysicalFilename in eslint plugin

### DIFF
--- a/packages/eslint-plugin-obsidian/rules/ast/utils.ts
+++ b/packages/eslint-plugin-obsidian/rules/ast/utils.ts
@@ -1,5 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types';
-import type { ArrayExpressionElement } from '../unresolvedProviderDependencies/types';
+import type { ArrayExpressionElement } from '../types';
 import { assertDefined } from '../utils/assertions';
 
 export function isClassLike(node: TSESTree.Node): node is TSESTree.ClassDeclaration {

--- a/packages/eslint-plugin-obsidian/rules/dto/context.ts
+++ b/packages/eslint-plugin-obsidian/rules/dto/context.ts
@@ -1,0 +1,17 @@
+import type { TSESTree } from '@typescript-eslint/types';
+import type { RuleContext } from '@typescript-eslint/utils/ts-eslint';
+
+export class Context<MessageId extends string = any, Options extends any[] = any> {
+  constructor(private context: RuleContext<MessageId, Options>) { }
+
+  /**
+   * Returns the fully qualified path to the current file being linted.
+   */
+  public get currentFilePath() {
+    return this.context.getPhysicalFilename?.()!;
+  }
+
+  public reportError(node: TSESTree.Node, messageId: MessageId, data: any) {
+    this.context.report({ messageId, node, data });
+  }
+}

--- a/packages/eslint-plugin-obsidian/rules/types.ts
+++ b/packages/eslint-plugin-obsidian/rules/types.ts
@@ -1,0 +1,3 @@
+import type { TSESTree } from '@typescript-eslint/types';
+
+export type ArrayExpressionElement = TSESTree.ArrayExpression['elements'][number];

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/createRule.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/createRule.ts
@@ -1,6 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import { Clazz } from '../dto/class';
-import type { Context } from './types';
+import { Context } from '../dto/context';
 import { GraphHandler } from './graphHandler';
 import { FileReader } from '../framework/fileReader';
 import { DependencyResolver } from './dependencyResolver';

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/dependencyResolver.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/dependencyResolver.ts
@@ -2,13 +2,13 @@ import { ClassFile } from '../dto/classFile';
 import type { Import } from '../dto/import';
 import type { Clazz } from '../dto/class';
 import type { SubgraphResolver } from './subgraphResolver';
-import type { Context } from './types';
+import type { Context } from '../dto/context';
 
 export class DependencyResolver {
   constructor(private subgraphResolver: SubgraphResolver) { }
 
   public resolve(context: Context, clazz: Clazz, imports: Import[]) {
-    const classWithImports = new ClassFile(clazz, imports, context.physicalFilename!);
+    const classWithImports = new ClassFile(clazz, imports, context.currentFilePath);
     return [
       ...this.getGraphDependencies(classWithImports),
       ...this.getDependenciesFromSubgraphs(classWithImports),

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/errorReporter.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/errorReporter.ts
@@ -1,17 +1,11 @@
 import type { TSESTree } from '@typescript-eslint/types';
-import type { Context } from './types';
+import type { Context } from '../dto/context';
 
 export function reportErrorIfDependencyIsUnresolved(
   context: Context,
   {error, param, node}: {error: boolean; param?: string; node?: TSESTree.Node},
 ) {
-  if (error) {
-    context.report({
-      node: node!,
-      messageId: 'unresolved-provider-dependencies',
-      data: {
-        dependencyName: param,
-      },
-    });
+  if (error && node) {
+    context.reportError(node, 'unresolved-provider-dependencies', {dependencyName: param});
   }
 }

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/graphHandler.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/graphHandler.ts
@@ -1,5 +1,5 @@
 import type { Clazz } from '../dto/class';
-import type { Context } from './types';
+import type { Context } from '../dto/context';
 import { reportErrorIfDependencyIsUnresolved } from './errorReporter';
 import type { DependencyResolver } from './dependencyResolver';
 import type { Import } from '../dto/import';

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/index.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/index.ts
@@ -3,6 +3,7 @@ import type { RuleContext } from '@typescript-eslint/utils/ts-eslint';
 import { create } from './createRule';
 import { PathResolver } from '../framework/pathResolver';
 import { FileReader } from '../framework/fileReader';
+import {Context} from '../dto/context';
 
 type Rule = TSESLint.RuleModule<'unresolved-provider-dependencies', []>;
 
@@ -15,7 +16,7 @@ export const unresolvedProviderDependenciesGenerator = (
 ) => {
   return createRule({
     create: (context: RuleContext<'unresolved-provider-dependencies', []>) => {
-      return create(context, new FileReader(pathResolver));
+      return create(new Context(context), new FileReader(pathResolver));
     },
     name: 'unresolved-provider-dependencies',
     meta: {

--- a/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/types.ts
+++ b/packages/eslint-plugin-obsidian/rules/unresolvedProviderDependencies/types.ts
@@ -1,6 +1,0 @@
-import type { TSESTree } from '@typescript-eslint/types';
-import type { RuleContext } from '@typescript-eslint/utils/ts-eslint';
-
-export type Context = RuleContext<'unresolved-provider-dependencies', []>;
-
-export type ArrayExpressionElement = TSESTree.ArrayExpression['elements'][number];


### PR DESCRIPTION
Apparently context.physicalFilename returns undefined when linting an actual file, getPhysicalFilename seems to work ¯\_(ツ)_/¯