### PR TITLE
Introduce an ESLint rule that ensures injected components are typed properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ packages/react-obsidian/coverage/
 .yarn/install-state.gz
 documentation/.yarn/cache
 documentation/.yarn/install-state.gz
+.vscode/yw_helper_history.txt

--- a/packages/eslint-plugin-obsidian/.eslintrc.json
+++ b/packages/eslint-plugin-obsidian/.eslintrc.json
@@ -32,7 +32,9 @@
       {
         "code": 115,
         "comments": 200,
-        "ignoreRegExpLiterals": true
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true
       }
     ],
     "@stylistic/no-extra-semi": "error",

--- a/packages/eslint-plugin-obsidian/package.json
+++ b/packages/eslint-plugin-obsidian/package.json
@@ -16,7 +16,8 @@
   ],
   "peerDependencies": {
     "eslint": "8.x.x",
-    "react-obsidian": "2.x.x"
+    "react-obsidian": "2.x.x",
+    "eslint-plugin-obsidian": "*"
   },
   "dependencies": {
     "@typescript-eslint/parser": "6.6.x",

--- a/packages/eslint-plugin-obsidian/package.json
+++ b/packages/eslint-plugin-obsidian/package.json
@@ -16,8 +16,8 @@
   ],
   "peerDependencies": {
     "eslint": "8.x.x",
-    "react-obsidian": "2.x.x",
-    "eslint-plugin-obsidian": "*"
+    "eslint-plugin-obsidian": "*",
+    "react-obsidian": "2.x.x"
   },
   "dependencies": {
     "@typescript-eslint/parser": "6.6.x",

--- a/packages/eslint-plugin-obsidian/src/dto/callExpression.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/callExpression.ts
@@ -18,7 +18,7 @@ export class CallExpression {
     }
 
     get generics() {
-      return new Generics(this.node.typeArguments);
+      return this.node.typeArguments && new Generics(this.node.typeArguments);
     }
 
     private get callee(): TSESTree.Identifier {

--- a/packages/eslint-plugin-obsidian/src/dto/callExpression.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/callExpression.ts
@@ -1,0 +1,27 @@
+import type { TSESTree } from '@typescript-eslint/types';
+import { Identifier } from './identifier';
+import { Generics } from './generics';
+
+export class CallExpression {
+    constructor(readonly node: TSESTree.CallExpression) {}
+
+    get name(): string {
+        return this.callee.name;
+    }
+
+    get parent(): TSESTree.Node {
+        return this.node.parent!;
+    }
+
+    get arguments(): Identifier[] {
+        return this.node.arguments.map((arg) => new Identifier(arg));
+    }
+
+    get generics() {
+      return new Generics(this.node.typeArguments);
+    }
+
+    private get callee(): TSESTree.Identifier {
+        return this.node.callee as TSESTree.Identifier;
+    }
+}

--- a/packages/eslint-plugin-obsidian/src/dto/callExpression.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/callExpression.ts
@@ -5,6 +5,10 @@ import { Generics } from './generics';
 export class CallExpression {
     constructor(readonly node: TSESTree.CallExpression) {}
 
+    public isExpression(name: string): boolean {
+        return this.name === name;
+    }
+
     get name(): string {
         return this.callee.name;
     }

--- a/packages/eslint-plugin-obsidian/src/dto/class.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/class.ts
@@ -1,7 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import { Decorator } from './decorator';
 import { assertDefined } from '../utils/assertions';
-import { isMethodDefinition } from '../ast/utils';
+import { isMethodDefinition } from '../utils/ast';
 import { Method } from './method';
 
 export class Clazz {

--- a/packages/eslint-plugin-obsidian/src/dto/componentProps.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/componentProps.ts
@@ -1,5 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types';
-import { isTypeAnnotation, isTypeIntersection } from '../utils/ast';
+import { isAnyType, isTypeAnnotation, isTypeIntersection } from '../utils/ast';
 import { SingleType } from './singleType';
 import { TypeIntersection } from './typeIntersection';
 import { MissingType } from './missingType';
@@ -15,7 +15,9 @@ export class ComponentProps {
   }
 
   private getType(typeAnnotation: TSESTree.TypeNode | undefined, props: TSESTree.Identifier) {
+    if (!typeAnnotation) return new MissingType();
     if (isTypeIntersection(typeAnnotation)) return new TypeIntersection(typeAnnotation);
+    if (isAnyType(typeAnnotation)) return new MissingType();
     if (isTypeAnnotation(props?.typeAnnotation)) return new SingleType(props);
     return new MissingType();
   }

--- a/packages/eslint-plugin-obsidian/src/dto/componentProps.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/componentProps.ts
@@ -1,0 +1,24 @@
+import type { TSESTree } from '@typescript-eslint/types';
+import { isTypeAnnotation, isTypeIntersection } from '../utils/ast';
+import { SingleType } from './singleType';
+import { TypeIntersection } from './typeIntersection';
+import { MissingType } from './missingType';
+import type { Type } from './type';
+
+export class ComponentProps {
+  constructor(private node: TSESTree.ArrowFunctionExpression) { }
+
+  get type(): Type {
+    const props = this.node.params[0] as TSESTree.Identifier;
+    const typeAnnotation = props?.typeAnnotation?.typeAnnotation;
+    return this.getType(typeAnnotation, props);
+  }
+
+  private getType(typeAnnotation: TSESTree.TypeNode | undefined, props: TSESTree.Identifier) {
+    switch (true) {
+      case isTypeIntersection(typeAnnotation): return new TypeIntersection(typeAnnotation);
+      case isTypeAnnotation(props?.typeAnnotation): return new SingleType(props);
+      default: return new MissingType();
+    }
+  }
+}

--- a/packages/eslint-plugin-obsidian/src/dto/componentProps.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/componentProps.ts
@@ -15,10 +15,8 @@ export class ComponentProps {
   }
 
   private getType(typeAnnotation: TSESTree.TypeNode | undefined, props: TSESTree.Identifier) {
-    switch (true) {
-      case isTypeIntersection(typeAnnotation): return new TypeIntersection(typeAnnotation);
-      case isTypeAnnotation(props?.typeAnnotation): return new SingleType(props);
-      default: return new MissingType();
-    }
+    if (isTypeIntersection(typeAnnotation)) return new TypeIntersection(typeAnnotation);
+    if (isTypeAnnotation(props?.typeAnnotation)) return new SingleType(props);
+    return new MissingType();
   }
 }

--- a/packages/eslint-plugin-obsidian/src/dto/componentProps.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/componentProps.ts
@@ -1,24 +1,27 @@
 import type { TSESTree } from '@typescript-eslint/types';
-import { isAnyType, isTypeAnnotation, isTypeIntersection } from '../utils/ast';
+import {
+isAnyType,
+isTypeAnnotation,
+isTypeIntersection,
+isTypeReference,
+} from '../utils/ast';
 import { SingleType } from './singleType';
 import { TypeIntersection } from './typeIntersection';
 import { MissingType } from './missingType';
 import type { Type } from './type';
+import { TypeReference } from './typeReference';
 
 export class ComponentProps {
-  constructor(private node: TSESTree.ArrowFunctionExpression) { }
+  constructor(props: TSESTree.Parameter);
+  constructor(private props: TSESTree.Identifier) { }
 
   get type(): Type {
-    const props = this.node.params[0] as TSESTree.Identifier;
-    const typeAnnotation = props?.typeAnnotation?.typeAnnotation;
-    return this.getType(typeAnnotation, props);
-  }
-
-  private getType(typeAnnotation: TSESTree.TypeNode | undefined, props: TSESTree.Identifier) {
+    const typeAnnotation = this.props?.typeAnnotation?.typeAnnotation;
     if (!typeAnnotation) return new MissingType();
     if (isTypeIntersection(typeAnnotation)) return new TypeIntersection(typeAnnotation);
     if (isAnyType(typeAnnotation)) return new MissingType();
-    if (isTypeAnnotation(props?.typeAnnotation)) return new SingleType(props);
+    if (isTypeReference(typeAnnotation)) return new TypeReference(typeAnnotation);
+    if (isTypeAnnotation(this.props?.typeAnnotation)) return new SingleType(this.props);
     return new MissingType();
   }
 }

--- a/packages/eslint-plugin-obsidian/src/dto/decorator.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/decorator.ts
@@ -1,5 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types';
-import { getDecoratorProperty } from '../ast/utils';
+import { getDecoratorProperty } from '../utils/ast';
 import { Property } from './property';
 
 interface CallExpression extends TSESTree.CallExpression {

--- a/packages/eslint-plugin-obsidian/src/dto/file.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/file.ts
@@ -1,15 +1,14 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import { Clazz } from './class';
-import { getClassDeclaration, isClassLike, isImportDeclaration } from '../ast/utils';
+import { getClassDeclaration, isClassLike, isImportDeclaration } from '../utils/ast';
 import { Import } from './import';
 import { ClassFile } from './classFile';
 import { assertDefined } from '../utils/assertions';
+import { Variable } from './variable';
 
 export class File {
-  constructor(
-    private program: TSESTree.Program,
-    private path: string,
-  ) { }
+  constructor(program: TSESTree.Program, path?: string);
+  constructor(private program: TSESTree.Program,private path: string) { }
 
   public requireGraph(name: string) {
     const graph = this.classNodes.find((node) => {
@@ -51,5 +50,13 @@ export class File {
       .filter((clazz: Clazz | undefined) => {
         return clazz ? clazz.decoratorNames.includes('Graph') : false;
       }) as Clazz[];
+  }
+
+  get variables() {
+    return this.body
+      .filter((node) => node.type === 'VariableDeclaration')
+      .map((node) => node.declarations)
+      .flat()
+      .map((node) => new Variable(node));
   }
 }

--- a/packages/eslint-plugin-obsidian/src/dto/file.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/file.ts
@@ -1,6 +1,11 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import { Clazz } from './class';
-import { getClassDeclaration, isClassLike, isImportDeclaration } from '../utils/ast';
+import {
+getClassDeclaration,
+isClassLike,
+isImportDeclaration,
+isVariableDeclaration,
+} from '../utils/ast';
 import { Import } from './import';
 import { ClassFile } from './classFile';
 import { assertDefined } from '../utils/assertions';
@@ -54,7 +59,7 @@ export class File {
 
   get variables() {
     return this.body
-      .filter((node) => node.type === 'VariableDeclaration')
+      .filter(isVariableDeclaration)
       .map((node) => node.declarations)
       .flat()
       .map((node) => new Variable(node));

--- a/packages/eslint-plugin-obsidian/src/dto/functionalComponent.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/functionalComponent.ts
@@ -1,5 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types';
-import { isTypeIntersection } from '../utils/ast';
+import { isTypeAnnotation, isTypeIntersection } from '../utils/ast';
 import { Identifier } from './identifier';
 
 export class FunctionalComponent {
@@ -13,6 +13,10 @@ export class FunctionalComponent {
         return new Identifier(typeRef.typeName).name;
       });
       return types;
+    }
+    if (isTypeAnnotation(this.props?.typeAnnotation)) {
+      const typeRef = this.props?.typeAnnotation?.typeAnnotation as TSESTree.TSTypeReference;
+      return [new Identifier(typeRef.typeName).name];
     }
     return [];
   }

--- a/packages/eslint-plugin-obsidian/src/dto/functionalComponent.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/functionalComponent.ts
@@ -1,0 +1,23 @@
+import type { TSESTree } from '@typescript-eslint/types';
+import { isTypeIntersection } from '../utils/ast';
+import { Identifier } from './identifier';
+
+export class FunctionalComponent {
+  constructor(private node: TSESTree.ArrowFunctionExpression) {}
+
+  get propsType(): string[] {
+    const typeAnnotation = this.props.typeAnnotation?.typeAnnotation;
+    if (isTypeIntersection(typeAnnotation)) {
+      const types = typeAnnotation.types.map((type) => {
+        const typeRef = type as TSESTree.TSTypeReference;
+        return new Identifier(typeRef.typeName).name;
+      });
+      return types;
+    }
+    return [];
+  }
+
+  get props(): TSESTree.Identifier {
+    return this.node.params[0] as TSESTree.Identifier;
+  }
+}

--- a/packages/eslint-plugin-obsidian/src/dto/functionalComponent.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/functionalComponent.ts
@@ -1,27 +1,10 @@
 import type { TSESTree } from '@typescript-eslint/types';
-import { isTypeAnnotation, isTypeIntersection } from '../utils/ast';
-import { Identifier } from './identifier';
+import { ComponentProps } from './componentProps';
 
 export class FunctionalComponent {
   constructor(private node: TSESTree.ArrowFunctionExpression) {}
 
-  get propsType(): string[] {
-    const typeAnnotation = this.props?.typeAnnotation?.typeAnnotation;
-    if (isTypeIntersection(typeAnnotation)) {
-      const types = typeAnnotation.types.map((type) => {
-        const typeRef = type as TSESTree.TSTypeReference;
-        return new Identifier(typeRef.typeName).name;
-      });
-      return types;
-    }
-    if (isTypeAnnotation(this.props?.typeAnnotation)) {
-      const typeRef = this.props?.typeAnnotation?.typeAnnotation as TSESTree.TSTypeReference;
-      return [new Identifier(typeRef.typeName).name];
-    }
-    return [];
-  }
-
-  get props(): TSESTree.Identifier | undefined {
-    return this.node.params[0] as TSESTree.Identifier;
+  get props(): ComponentProps {
+    return new ComponentProps(this.node);
   }
 }

--- a/packages/eslint-plugin-obsidian/src/dto/functionalComponent.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/functionalComponent.ts
@@ -5,6 +5,6 @@ export class FunctionalComponent {
   constructor(private node: TSESTree.ArrowFunctionExpression) {}
 
   get props(): ComponentProps {
-    return new ComponentProps(this.node);
+    return new ComponentProps(this.node.params[0]);
   }
 }

--- a/packages/eslint-plugin-obsidian/src/dto/functionalComponent.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/functionalComponent.ts
@@ -6,7 +6,7 @@ export class FunctionalComponent {
   constructor(private node: TSESTree.ArrowFunctionExpression) {}
 
   get propsType(): string[] {
-    const typeAnnotation = this.props.typeAnnotation?.typeAnnotation;
+    const typeAnnotation = this.props?.typeAnnotation?.typeAnnotation;
     if (isTypeIntersection(typeAnnotation)) {
       const types = typeAnnotation.types.map((type) => {
         const typeRef = type as TSESTree.TSTypeReference;
@@ -17,7 +17,7 @@ export class FunctionalComponent {
     return [];
   }
 
-  get props(): TSESTree.Identifier {
+  get props(): TSESTree.Identifier | undefined {
     return this.node.params[0] as TSESTree.Identifier;
   }
 }

--- a/packages/eslint-plugin-obsidian/src/dto/generics.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/generics.ts
@@ -1,0 +1,21 @@
+import type { TSESTree } from '@typescript-eslint/types';
+import { assertDefined } from '../utils/assertions';
+import { Identifier } from './identifier';
+
+export class Generics {
+  constructor(node: TSESTree.TSTypeParameterInstantiation | undefined);
+  constructor(readonly node: TSESTree.TSTypeParameterInstantiation) {
+    assertDefined(node);
+  }
+
+  get types(): string[] {
+    return this.params
+      .map((param: TSESTree.TSTypeReference) => {
+        return new Identifier(param.typeName).name;
+      });
+  }
+
+  private get params() {
+    return this.node.params as TSESTree.TSTypeReference[];
+  }
+}

--- a/packages/eslint-plugin-obsidian/src/dto/generics.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/generics.ts
@@ -1,6 +1,9 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import { assertDefined } from '../utils/assertions';
-import { Identifier } from './identifier';
+import { isTypeLiteral } from '../utils/ast';
+import { TypeLiteral } from './typeLiteral';
+import type { Type } from './type';
+import { TypeReference } from './typeReference';
 
 export class Generics {
   constructor(node: TSESTree.TSTypeParameterInstantiation | undefined);
@@ -8,10 +11,10 @@ export class Generics {
     assertDefined(node);
   }
 
-  get types(): string[] {
+  get types(): Type[] {
     return this.params
       .map((param: TSESTree.TSTypeReference) => {
-        return new Identifier(param.typeName).name;
+        return isTypeLiteral(param) ? new TypeLiteral() : new TypeReference(param);
       });
   }
 

--- a/packages/eslint-plugin-obsidian/src/dto/identifier.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/identifier.ts
@@ -1,0 +1,10 @@
+import type { TSESTree } from '@typescript-eslint/types';
+
+export class Identifier {
+  constructor(node: TSESTree.Node);
+  constructor(private node: TSESTree.Identifier) {}
+
+  get name(): string {
+    return this.node.name;
+  }
+}

--- a/packages/eslint-plugin-obsidian/src/dto/missingType.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/missingType.ts
@@ -1,0 +1,9 @@
+import type { Type } from './type';
+
+export class MissingType implements Type {
+  constructor() {}
+
+  asString(): string[] {
+    return [];
+  }
+}

--- a/packages/eslint-plugin-obsidian/src/dto/missingType.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/missingType.ts
@@ -3,7 +3,15 @@ import type { Type } from './type';
 export class MissingType implements Type {
   constructor() {}
 
-  asString(): string[] {
+  toString(): string[] {
     return [];
+  }
+
+  isEmpty(): boolean {
+    return true;
+  }
+
+  equals(types: Type[]): boolean {
+    return types.length === 0 || types.length === 1 && types[0].isEmpty();
   }
 }

--- a/packages/eslint-plugin-obsidian/src/dto/singleType.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/singleType.ts
@@ -5,8 +5,16 @@ import { Identifier } from './identifier';
 export class SingleType implements Type {
   constructor(private props: TSESTree.Identifier) {}
 
-  asString(): string[] {
+  toString(): string[] {
     const typeRef = this.props?.typeAnnotation?.typeAnnotation as TSESTree.TSTypeReference;
     return [new Identifier(typeRef.typeName).name];
+  }
+
+  isEmpty(): boolean {
+    return false;
+  }
+
+  equals(types: Type[]): boolean {
+    return types.length === 1 && types[0].toString() === this.toString();
   }
 }

--- a/packages/eslint-plugin-obsidian/src/dto/singleType.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/singleType.ts
@@ -1,0 +1,12 @@
+import type { TSESTree } from '@typescript-eslint/types';
+import type { Type } from './type';
+import { Identifier } from './identifier';
+
+export class SingleType implements Type {
+  constructor(private props: TSESTree.Identifier) {}
+
+  asString(): string[] {
+    const typeRef = this.props?.typeAnnotation?.typeAnnotation as TSESTree.TSTypeReference;
+    return [new Identifier(typeRef.typeName).name];
+  }
+}

--- a/packages/eslint-plugin-obsidian/src/dto/type.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/type.ts
@@ -1,3 +1,5 @@
 export interface Type {
-  asString(): string[];
+  toString(): string[];
+  isEmpty(): boolean;
+  equals(types: Type[]): boolean;
 }

--- a/packages/eslint-plugin-obsidian/src/dto/type.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/type.ts
@@ -1,0 +1,3 @@
+export interface Type {
+  asString(): string[];
+}

--- a/packages/eslint-plugin-obsidian/src/dto/typeIntersection.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/typeIntersection.ts
@@ -1,0 +1,14 @@
+import type { TSESTree } from '@typescript-eslint/types';
+import { Type } from './type';
+import { Identifier } from './identifier';
+
+export class TypeIntersection implements Type {
+  constructor(private typeAnnotation: TSESTree.TSIntersectionType) {}
+
+  asString(): string[] {
+    return this.typeAnnotation.types.map((type) => {
+      const typeRef = type as TSESTree.TSTypeReference;
+      return new Identifier(typeRef.typeName).name;
+    });
+  }
+}

--- a/packages/eslint-plugin-obsidian/src/dto/typeIntersection.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/typeIntersection.ts
@@ -1,14 +1,26 @@
 import type { TSESTree } from '@typescript-eslint/types';
+import { isEqual } from 'lodash';
 import { Type } from './type';
 import { Identifier } from './identifier';
 
 export class TypeIntersection implements Type {
-  constructor(private typeAnnotation: TSESTree.TSIntersectionType) {}
+  constructor(private typeAnnotation: TSESTree.TSIntersectionType) { }
 
-  asString(): string[] {
+  toString(): string[] {
     return this.typeAnnotation.types.map((type) => {
       const typeRef = type as TSESTree.TSTypeReference;
       return new Identifier(typeRef.typeName).name;
     });
+  }
+
+  isEmpty(): boolean {
+    return this.typeAnnotation.types.length === 0;
+  }
+
+  equals(types: Type[]): boolean {
+    return isEqual(
+      this.toString(),
+      types.map((type) => type.toString()).flat(),
+    );
   }
 }

--- a/packages/eslint-plugin-obsidian/src/dto/typeLiteral.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/typeLiteral.ts
@@ -1,0 +1,19 @@
+import type { Type } from './type';
+
+export class TypeLiteral implements Type {
+  static isTypeLiteral(type: Type): type is TypeLiteral {
+    return type instanceof TypeLiteral;
+  }
+
+  toString(): string[] {
+    throw new Error('Method not implemented.');
+  }
+
+  isEmpty(): boolean {
+    throw new Error('Method not implemented.');
+  }
+
+  equals(types: Type[]): boolean {
+    return types.length === 1 && types[0].toString() === this.toString();
+  }
+}

--- a/packages/eslint-plugin-obsidian/src/dto/typeReference.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/typeReference.ts
@@ -1,0 +1,22 @@
+import type { TSESTree } from '@typescript-eslint/types';
+import { isEqual } from 'lodash';
+import type { Type } from './type';
+import { Identifier } from './identifier';
+
+export class TypeReference implements Type {
+  constructor(private node: TSESTree.TSTypeReference) {}
+
+  toString(): string[] {
+    return [new Identifier(this.node.typeName).name];
+  }
+
+  isEmpty(): boolean {
+    return false;
+  }
+
+  equals(types: Type[]): boolean {
+    const a = this.toString();
+    const b = types.map((type) => type.toString()).flat();
+    return isEqual(a, b);
+  }
+}

--- a/packages/eslint-plugin-obsidian/src/dto/variable.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/variable.ts
@@ -1,0 +1,19 @@
+import type { TSESTree } from '@typescript-eslint/types';
+import assert from 'assert';
+
+export class Variable {
+  constructor(private node: TSESTree.VariableDeclarator) {}
+
+  get name() {
+    return (this.node.id as TSESTree.Identifier).name;
+  }
+
+  get isArrowFunction(): boolean {
+    return this.node.init?.type === 'ArrowFunctionExpression';
+  }
+
+  get arrowFunction(): TSESTree.ArrowFunctionExpression {
+    assert(this.isArrowFunction, 'Variable does not represent an arrow function');
+    return this.node.init as TSESTree.ArrowFunctionExpression;
+  }
+}

--- a/packages/eslint-plugin-obsidian/src/index.ts
+++ b/packages/eslint-plugin-obsidian/src/index.ts
@@ -1,9 +1,11 @@
 const { unresolvedProviderDependenciesGenerator } = require('./rules/unresolvedProviderDependencies');
 const { noCircularDependenciesGenerator } = require('./rules/noCircularDependency');
+const { stronglyTypedInjectComponentGenerator } = require('./rules/stronglyTypedInjectComponent');
 
 module.exports = {
   rules: {
     'unresolved-provider-dependencies': unresolvedProviderDependenciesGenerator(),
     'no-circular-dependencies': noCircularDependenciesGenerator(),
+    'strongly-typed-inject-component': stronglyTypedInjectComponentGenerator(),
   },
 };

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/createRule.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/createRule.ts
@@ -1,0 +1,13 @@
+import type { TSESTree } from '@typescript-eslint/types';
+import { Context } from '../../dto/context';
+import { InjectComponentHandler } from './injectComponentHandler';
+
+export function create(context: Context) {
+  const injectComponentHandler = new InjectComponentHandler(context);
+
+  return {
+    CallExpression(node: TSESTree.CallExpression) {
+      injectComponentHandler.handle(node);
+    },
+  };
+}

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/createRule.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/createRule.ts
@@ -3,9 +3,13 @@ import { Context } from '../../dto/context';
 import { InjectComponentHandler } from './injectComponentHandler';
 import { CallExpression } from '../../dto/callExpression';
 import { ErrorReporter } from './errorReporter';
+import { TypeValidator } from './typeValidator';
 
 export function create(context: Context) {
-  const injectComponentHandler = new InjectComponentHandler(new ErrorReporter(context));
+  const injectComponentHandler = new InjectComponentHandler(
+    new ErrorReporter(context),
+    new TypeValidator(),
+  );
 
   return {
     CallExpression(node: TSESTree.CallExpression) {

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/createRule.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/createRule.ts
@@ -2,9 +2,10 @@ import type { TSESTree } from '@typescript-eslint/types';
 import { Context } from '../../dto/context';
 import { InjectComponentHandler } from './injectComponentHandler';
 import { CallExpression } from '../../dto/callExpression';
+import { ErrorReporter } from './errorReporter';
 
 export function create(context: Context) {
-  const injectComponentHandler = new InjectComponentHandler(context);
+  const injectComponentHandler = new InjectComponentHandler(new ErrorReporter(context));
 
   return {
     CallExpression(node: TSESTree.CallExpression) {

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/createRule.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/createRule.ts
@@ -1,13 +1,14 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import { Context } from '../../dto/context';
 import { InjectComponentHandler } from './injectComponentHandler';
+import { CallExpression } from '../../dto/callExpression';
 
 export function create(context: Context) {
   const injectComponentHandler = new InjectComponentHandler(context);
 
   return {
     CallExpression(node: TSESTree.CallExpression) {
-      injectComponentHandler.handle(node);
+      injectComponentHandler.handle(new CallExpression(node));
     },
   };
 }

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/errorReporter.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/errorReporter.ts
@@ -15,7 +15,7 @@ export class ErrorReporter {
         node,
         'strongly-typed-inject-component',
         {
-          expectation: `injectedComponent<${types[0]}, ${types[1]}>`,
+          expectation: `injectedComponent<${types?.join(', ')}>`,
         },
       );
     }

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/errorReporter.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/errorReporter.ts
@@ -1,15 +1,10 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import type { Context } from '../../dto/context';
 
-type Report = {
-  types?: string[];
-  node?: TSESTree.Node;
-};
-
 export class ErrorReporter {
   constructor(private context: Context) { }
 
-  public report({ types, node }: Report) {
+  public report(types?: string[], node?: TSESTree.Node) {
     if (types && node) {
       this.context.reportError(
         node,

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/errorReporter.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/errorReporter.ts
@@ -1,16 +1,17 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import type { Context } from '../../dto/context';
+import type { Type } from '../../dto/type';
 
 export class ErrorReporter {
   constructor(private context: Context) { }
 
-  public report(types?: string[], node?: TSESTree.Node) {
+  public report(types?: Type, node?: TSESTree.Node) {
     if (types && node) {
       this.context.reportError(
         node,
         'strongly-typed-inject-component',
         {
-          expectation: `injectedComponent<${types?.join(', ')}>`,
+          expectation: `injectedComponent<${types.toString()}>`,
         },
       );
     }

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/errorReporter.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/errorReporter.ts
@@ -1,0 +1,23 @@
+import type { TSESTree } from '@typescript-eslint/types';
+import type { Context } from '../../dto/context';
+
+type Report = {
+  types?: string[];
+  node?: TSESTree.Node;
+};
+
+export class ErrorReporter {
+  constructor(private context: Context) { }
+
+  public report({ types, node }: Report) {
+    if (types && node) {
+      this.context.reportError(
+        node,
+        'strongly-typed-inject-component',
+        {
+          expectation: `injectedComponent<${types[0]}, ${types[1]}>`,
+        },
+      );
+    }
+  }
+}

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/index.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/index.ts
@@ -1,0 +1,31 @@
+import { ESLintUtils, type TSESLint } from '@typescript-eslint/utils';
+import type { RuleContext } from '@typescript-eslint/utils/ts-eslint';
+import { create } from './createRule';
+import {Context} from '../../dto/context';
+
+type Rule = TSESLint.RuleModule<'strongly-typed-inject-component', []>;
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://wix-incubator.github.io/obsidian/docs/documentation/meta/eslint#${name}`,
+);
+
+export const stronglyTypedInjectComponentGenerator = () => {
+  return createRule({
+    create: (context: RuleContext<'strongly-typed-inject-component', []>) => {
+      return create(new Context(context));
+    },
+    name: 'strongly-typed-inject-component',
+    meta: {
+      docs: {
+        description: 'Calling injectComponent without prop types is a bad practice and a common source of bugs',
+        recommended: 'strict',
+      },
+      messages: {
+        'strongly-typed-inject-component': 'The call to injectComponent is missing prop types. It should be typed as: {{expectation}}',
+      },
+      schema: [],
+      type: 'problem',
+    },
+    defaultOptions: [],
+  }) satisfies Rule;
+};

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/index.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/index.ts
@@ -17,7 +17,7 @@ export const stronglyTypedInjectComponentGenerator = () => {
     name: 'strongly-typed-inject-component',
     meta: {
       docs: {
-        description: 'Calling injectComponent without prop types is a bad practice and a common source of bugs',
+        description: 'Calling injectComponent without prop types is a bad practice and a common source of bugs.',
         recommended: 'strict',
       },
       messages: {

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/injectComponentHandler.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/injectComponentHandler.ts
@@ -1,0 +1,10 @@
+import type { Context } from '../../dto/context';
+
+export class InjectComponentHandler {
+  constructor(private _context: Context) {
+  }
+
+  handle(node: unknown) {
+    console.log(node);
+  }
+}

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/injectComponentHandler.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/injectComponentHandler.ts
@@ -1,47 +1,26 @@
-import { isEmpty } from 'lodash';
+import type { TSESTree } from '@typescript-eslint/types';
 import type { CallExpression } from '../../dto/callExpression';
 import { requireProgram } from '../../utils/ast';
 import { File } from '../../dto/file';
-import { FunctionalComponent } from '../../dto/functionalComponent';
 import type { ErrorReporter } from './errorReporter';
-import { equals } from '../../utils/array';
+import type { Identifier } from '../../dto/identifier';
+import type { TypeValidator } from './typeValidator';
 
 export class InjectComponentHandler {
-  constructor(private errorReporter: ErrorReporter) { }
+  constructor(private errorReporter: ErrorReporter, private typeValidator: TypeValidator) { }
 
   public handle(callExpression: CallExpression) {
-    if (this.isInjectComponentCall(callExpression)) {
-      const injectedComponent = this.getFile(callExpression)
-        .variables
-        .filter((variable) => variable.isArrowFunction)
-        .find((variable) => variable.name === this.getInjectedComponentName(callExpression));
-
-      if (injectedComponent) {
-        const componentProps = new FunctionalComponent(injectedComponent.arrowFunction).props.type.asString();
-        const injectComponentGenerics = callExpression.generics?.types;
-
-        if (
-          (isEmpty(componentProps) || equals(componentProps, injectComponentGenerics)) ||
-          (equals(componentProps, ['Injected']) && isEmpty(injectComponentGenerics))
-        ) return;
-
-        this.errorReporter.report({
-          types: componentProps,
-          node: callExpression.node,
-        });
-      }
+    if (callExpression.isExpression('injectComponent')) {
+      const injectedComponent = this.getInjectedComponent(callExpression.node, callExpression.arguments);
+      const { isError, componentProps } = this.typeValidator.validate(injectedComponent, callExpression.generics);
+      if (isError) this.errorReporter.report(componentProps, callExpression.node);
     }
   }
 
-  private isInjectComponentCall(node: CallExpression) {
-    return node.name === 'injectComponent';
-  }
-
-  private getInjectedComponentName(node: CallExpression) {
-    return node.arguments[0].name;
-  }
-
-  private getFile(node: CallExpression) {
-    return new File(requireProgram(node.node));
+  private getInjectedComponent(node: TSESTree.CallExpression, args: Identifier[]) {
+    return new File(requireProgram(node))
+      .variables
+      .filter((variable) => variable.isArrowFunction)
+      .find((variable) => variable.name === args[0].name);
   }
 }

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/injectComponentHandler.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/injectComponentHandler.ts
@@ -1,10 +1,42 @@
 import type { Context } from '../../dto/context';
+import type { CallExpression } from '../../dto/callExpression';
+import { requireProgram } from '../../utils/ast';
+import { File } from '../../dto/file';
+import { FunctionalComponent } from '../../dto/functionalComponent';
 
 export class InjectComponentHandler {
-  constructor(private _context: Context) {
+  constructor(private context: Context) { }
+
+  public handle(callExpression: CallExpression) {
+    if (this.isInjectComponentCall(callExpression)) {
+      const injectedComponent = this.getFile(callExpression)
+        .variables
+        .filter((variable) => variable.isArrowFunction)
+        .find((variable) => variable.name === this.getInjectedComponentName(callExpression));
+
+        if (injectedComponent) {
+          const functionalComponent = new FunctionalComponent(injectedComponent.arrowFunction);
+          const {propsType} = functionalComponent;
+
+          console.log(propsType);
+          console.log(callExpression.generics.types);
+
+          if (propsType !== callExpression.generics.types) {
+            // TODO: report error
+          }
+        }
+    }
   }
 
-  handle(node: unknown) {
-    console.log(node);
+  private isInjectComponentCall(node: CallExpression) {
+    return node.name === 'injectComponent';
+  }
+
+  private getInjectedComponentName(node: CallExpression) {
+    return node.arguments[0].name;
+  }
+
+  private getFile(node: CallExpression) {
+    return new File(requireProgram(node.node));
   }
 }

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/injectComponentHandler.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/injectComponentHandler.ts
@@ -17,13 +17,14 @@ export class InjectComponentHandler {
         .find((variable) => variable.name === this.getInjectedComponentName(callExpression));
 
       if (injectedComponent) {
-        const functionalComponent = new FunctionalComponent(injectedComponent.arrowFunction);
-        const componentProps = functionalComponent.propsType;
+        const componentProps = new FunctionalComponent(injectedComponent.arrowFunction).propsType;
+        const injectComponentGenerics = callExpression.generics?.types;
 
-        console.log(componentProps);
-        console.log(callExpression.generics?.types);
+        if (
+          (isEmpty(componentProps) || equals(componentProps, injectComponentGenerics)) ||
+          (equals(componentProps, ['Injected']) && isEmpty(injectComponentGenerics))
+        ) return;
 
-        if (isEmpty(componentProps) || equals(componentProps, callExpression.generics?.types)) return;
         this.errorReporter.report({
           types: componentProps,
           node: callExpression.node,

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/injectComponentHandler.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/injectComponentHandler.ts
@@ -17,7 +17,7 @@ export class InjectComponentHandler {
         .find((variable) => variable.name === this.getInjectedComponentName(callExpression));
 
       if (injectedComponent) {
-        const componentProps = new FunctionalComponent(injectedComponent.arrowFunction).propsType;
+        const componentProps = new FunctionalComponent(injectedComponent.arrowFunction).props.type.asString();
         const injectComponentGenerics = callExpression.generics?.types;
 
         if (

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/typeValidator.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/typeValidator.ts
@@ -1,0 +1,19 @@
+import { FunctionalComponent } from '../../dto/functionalComponent';
+import type { Generics } from '../../dto/generics';
+import type { Variable } from '../../dto/variable';
+import { equals, isEmpty } from '../../utils/array';
+
+export class TypeValidator {
+  public validate(injectedComponent?: Variable, generics?: Generics) {
+    if (!injectedComponent) return { isError: false };
+    const componentProps = new FunctionalComponent(injectedComponent.arrowFunction).props.type.asString();
+    const injectComponentGenerics = generics?.types;
+
+    if (
+      (isEmpty(componentProps) || equals(componentProps, injectComponentGenerics)) ||
+      (equals(componentProps, ['Injected']) && isEmpty(injectComponentGenerics))
+    ) return { isError: false };
+
+    return { isError: true, componentProps };
+  }
+}

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/typeValidator.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/typeValidator.ts
@@ -1,19 +1,28 @@
+import { isEqual } from 'lodash';
 import { FunctionalComponent } from '../../dto/functionalComponent';
 import type { Generics } from '../../dto/generics';
+import { TypeLiteral } from '../../dto/typeLiteral';
 import type { Variable } from '../../dto/variable';
-import { equals, isEmpty } from '../../utils/array';
+import { isEmpty } from '../../utils/array';
+import type { Type } from '../../dto/type';
 
 export class TypeValidator {
   public validate(injectedComponent?: Variable, generics?: Generics) {
     if (!injectedComponent) return { isError: false };
-    const componentProps = new FunctionalComponent(injectedComponent.arrowFunction).props.type.asString();
-    const injectComponentGenerics = generics?.types;
+    const componentProps = new FunctionalComponent(injectedComponent.arrowFunction).props.type;
+    const injectComponentGenerics = generics?.types || [];
+    return { isError: !this.comparePropsAndTypes(componentProps, injectComponentGenerics), componentProps };
+  }
 
-    if (
-      (isEmpty(componentProps) || equals(componentProps, injectComponentGenerics)) ||
-      (equals(componentProps, ['Injected']) && isEmpty(injectComponentGenerics))
-    ) return { isError: false };
+  private comparePropsAndTypes(componentProps: Type, injectComponentGenerics: Type[]): boolean {
+    return (
+      this.hasInlineType(injectComponentGenerics) ||
+      componentProps.equals(injectComponentGenerics) ||
+      isEmpty(injectComponentGenerics) && isEqual(componentProps.toString(), ['Injected'])
+    );
+  }
 
-    return { isError: true, componentProps };
+  private hasInlineType(injectComponentGenerics: import('/Users/guyc/workspace1/obsidian/packages/eslint-plugin-obsidian/src/dto/type').Type[]) {
+    return injectComponentGenerics.some(TypeLiteral.isTypeLiteral);
   }
 }

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/typeValidator.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/typeValidator.ts
@@ -22,7 +22,7 @@ export class TypeValidator {
     );
   }
 
-  private hasInlineType(injectComponentGenerics: import('/Users/guyc/workspace1/obsidian/packages/eslint-plugin-obsidian/src/dto/type').Type[]) {
+  private hasInlineType(injectComponentGenerics: Type[]) {
     return injectComponentGenerics.some(TypeLiteral.isTypeLiteral);
   }
 }

--- a/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/subgraphResolver.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/subgraphResolver.ts
@@ -1,5 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types';
-import { mapArrayExpression, requireProgram } from '../../ast/utils';
+import { mapArrayExpression, requireProgram } from '../../utils/ast';
 import { ClassFile } from '../../dto/classFile';
 import type { Property } from '../../dto/property';
 import { File } from '../../dto/file';

--- a/packages/eslint-plugin-obsidian/src/utils/array.ts
+++ b/packages/eslint-plugin-obsidian/src/utils/array.ts
@@ -1,5 +1,5 @@
-export function isEmpty(array: any[]) {
-    return array.length === 0;
+export function isEmpty(array?: any[]) {
+    return array === undefined || array.length === 0;
 }
 
 export function equals(a?: any[], b?: any[]) {

--- a/packages/eslint-plugin-obsidian/src/utils/array.ts
+++ b/packages/eslint-plugin-obsidian/src/utils/array.ts
@@ -1,7 +1,3 @@
 export function isEmpty(array?: any[]) {
     return array === undefined || array.length === 0;
 }
-
-export function equals(a?: any[], b?: any[]) {
-  return a && b && a.length === b.length && a.every((value, index) => value === b[index]);
-}

--- a/packages/eslint-plugin-obsidian/src/utils/array.ts
+++ b/packages/eslint-plugin-obsidian/src/utils/array.ts
@@ -1,0 +1,7 @@
+export function isEmpty(array: any[]) {
+    return array.length === 0;
+}
+
+export function equals(a?: any[], b?: any[]) {
+  return a && b && a.length === b.length && a.every((value, index) => value === b[index]);
+}

--- a/packages/eslint-plugin-obsidian/src/utils/ast.ts
+++ b/packages/eslint-plugin-obsidian/src/utils/ast.ts
@@ -1,6 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import type { ArrayExpressionElement } from '../types';
-import { assertDefined } from '../utils/assertions';
+import { assertDefined } from './assertions';
 
 export function isClassLike(node: TSESTree.Node): node is TSESTree.ClassDeclaration {
   switch (node.type) {
@@ -74,4 +74,8 @@ function getObjectProperty(obj: TSESTree.ObjectExpression, propertyName: string)
 
 export function mapArrayExpression<T>(array: TSESTree.ArrayExpression, map: (el: ArrayExpressionElement) => T) {
   return array.elements.map(map);
+}
+
+export function isTypeIntersection(node: TSESTree.Node | undefined): node is TSESTree.TSIntersectionType {
+  return node?.type === 'TSIntersectionType';
 }

--- a/packages/eslint-plugin-obsidian/src/utils/ast.ts
+++ b/packages/eslint-plugin-obsidian/src/utils/ast.ts
@@ -79,3 +79,7 @@ export function mapArrayExpression<T>(array: TSESTree.ArrayExpression, map: (el:
 export function isTypeIntersection(node: TSESTree.Node | undefined): node is TSESTree.TSIntersectionType {
   return node?.type === 'TSIntersectionType';
 }
+
+export function isVariableDeclaration(node: TSESTree.Node): node is TSESTree.VariableDeclaration {
+  return node.type === 'VariableDeclaration';
+}

--- a/packages/eslint-plugin-obsidian/src/utils/ast.ts
+++ b/packages/eslint-plugin-obsidian/src/utils/ast.ts
@@ -80,6 +80,10 @@ export function isTypeIntersection(node: TSESTree.Node | undefined): node is TSE
   return node?.type === 'TSIntersectionType';
 }
 
+export function isTypeAnnotation(node: TSESTree.Node | undefined): node is TSESTree.TSTypeAnnotation {
+  return node?.type === 'TSTypeAnnotation';
+}
+
 export function isVariableDeclaration(node: TSESTree.Node): node is TSESTree.VariableDeclaration {
   return node.type === 'VariableDeclaration';
 }

--- a/packages/eslint-plugin-obsidian/src/utils/ast.ts
+++ b/packages/eslint-plugin-obsidian/src/utils/ast.ts
@@ -84,6 +84,10 @@ export function isTypeAnnotation(node: TSESTree.Node | undefined): node is TSEST
   return node?.type === 'TSTypeAnnotation';
 }
 
+export function isAnyType(node: TSESTree.Node | undefined): node is TSESTree.TSAnyKeyword {
+  return node?.type === 'TSAnyKeyword';
+}
+
 export function isVariableDeclaration(node: TSESTree.Node): node is TSESTree.VariableDeclaration {
   return node.type === 'VariableDeclaration';
 }

--- a/packages/eslint-plugin-obsidian/src/utils/ast.ts
+++ b/packages/eslint-plugin-obsidian/src/utils/ast.ts
@@ -15,6 +15,14 @@ export function isClassLike(node: TSESTree.Node): node is TSESTree.ClassDeclarat
   }
 }
 
+export function isTypeReference(node?: TSESTree.Node): node is TSESTree.TSTypeReference {
+  return node?.type === 'TSTypeReference';
+}
+
+export function isTypeLiteral(node: TSESTree.Node): node is TSESTree.TSTypeLiteral {
+  return node.type === 'TSTypeLiteral';
+}
+
 export function isImportDeclaration(node: TSESTree.Node): node is TSESTree.ImportDeclaration {
   return node.type === 'ImportDeclaration';
 }
@@ -43,16 +51,6 @@ export function requireProgram(node: TSESTree.Node | undefined): TSESTree.Progra
       return node;
     default:
       return requireProgram(node.parent);
-  }
-}
-
-export function isImportLike(node: TSESTree.Node): boolean {
-  switch (node.type) {
-    case 'ImportDeclaration':
-    case 'ImportDefaultSpecifier':
-      return true;
-    default:
-      return false;
   }
 }
 

--- a/packages/eslint-plugin-obsidian/tests/noCircularDependencies/circularDependencies.test.ts
+++ b/packages/eslint-plugin-obsidian/tests/noCircularDependencies/circularDependencies.test.ts
@@ -1,11 +1,11 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
-import { noCircularDependenciesGenerator } from '../../src/rules/noCircularDependency';
 import {
   circularDependencyBetween3Providers,
   circularDependencyBetweenSomeOfTheProviders,
   invalidGraph,
 } from 'eslint-plugin-obsidian/tests/noCircularDependencies/code/invalidGraphs';
 import { validGraph } from 'eslint-plugin-obsidian/tests/noCircularDependencies/code/validGraphs';
+import { noCircularDependenciesGenerator } from '../../src/rules/noCircularDependency';
 
 const ruleTester = new RuleTester();
 

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/invalidGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/invalidGraphs.ts
@@ -1,54 +1,16 @@
-export const invalidGraph = `import { Graph, ObjectGraph, Provides } from 'src';
+export const invalidGraph = `
+import {injectComponent} from 'src';
 
-@Graph()
-class SimpleGraph extends ObjectGraph {
-  @Provides()
-  foo(bar: any): string {
-    return 'foo';
-  }
+type Own = {
+  name: string;
+};
 
-  @Provides()
-  bar(foo: any): string {
-    return 'bar';
-  }
-}`;
+type Injected = {
+  bar: Bar;
+};
 
-export const circularDependencyBetween3Providers = `import { Graph, ObjectGraph, Provides } from 'src';
+const _Foo = (props: Own & Injected) => {
+  return null;
+};
 
-@Graph()
-class SimpleGraph extends ObjectGraph {
-  @Provides()
-  foo(bar: any): string {
-    return 'foo';
-  }
-
-  @Provides()
-  bar(baz: any): string {
-    return 'bar';
-  }
-
-  @Provides()
-  baz(foo: any): string {
-    return 'baz';
-  }
-}`;
-
-export const circularDependencyBetweenSomeOfTheProviders = `import { Graph, ObjectGraph, Provides } from 'src';
-
-@Graph()
-class SimpleGraph extends ObjectGraph {
-  @Provides()
-  foo(bar: any): string {
-    return 'foo';
-  }
-
-  @Provides()
-  bar(baz: any): string {
-    return 'bar';
-  }
-
-  @Provides()
-  baz(bar: any): string {
-    return 'baz';
-  }
-}`;
+export const Foo = injectComponent(_Foo, SomeGraph);`;

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/invalidGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/invalidGraphs.ts
@@ -1,0 +1,54 @@
+export const invalidGraph = `import { Graph, ObjectGraph, Provides } from 'src';
+
+@Graph()
+class SimpleGraph extends ObjectGraph {
+  @Provides()
+  foo(bar: any): string {
+    return 'foo';
+  }
+
+  @Provides()
+  bar(foo: any): string {
+    return 'bar';
+  }
+}`;
+
+export const circularDependencyBetween3Providers = `import { Graph, ObjectGraph, Provides } from 'src';
+
+@Graph()
+class SimpleGraph extends ObjectGraph {
+  @Provides()
+  foo(bar: any): string {
+    return 'foo';
+  }
+
+  @Provides()
+  bar(baz: any): string {
+    return 'bar';
+  }
+
+  @Provides()
+  baz(foo: any): string {
+    return 'baz';
+  }
+}`;
+
+export const circularDependencyBetweenSomeOfTheProviders = `import { Graph, ObjectGraph, Provides } from 'src';
+
+@Graph()
+class SimpleGraph extends ObjectGraph {
+  @Provides()
+  foo(bar: any): string {
+    return 'foo';
+  }
+
+  @Provides()
+  bar(baz: any): string {
+    return 'bar';
+  }
+
+  @Provides()
+  baz(bar: any): string {
+    return 'baz';
+  }
+}`;

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/invalidGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/invalidGraphs.ts
@@ -14,3 +14,27 @@ const _Foo = (props: Own & Injected) => {
 };
 
 export const Foo = injectComponent(_Foo, SomeGraph);`;
+
+export const invalidGraphOnlyWithOwnProps = `
+import {injectComponent} from 'src';
+
+type Own = {
+  name: string;
+};
+
+const _Foo = (props: Own & Injected) => {
+  return null;
+};
+
+export const Foo = injectComponent(_Foo, SomeGraph);`;
+
+export const invalidGraphWithOwnPropsAndUnexpectedInjectedProps = `
+import {injectComponent} from 'src';
+
+type Own = { foo: any }
+
+const _Foo = (props: Own) => {
+  return null;
+};
+
+export const Foo = injectComponent<Own, Injected>(_Foo, SomeGraph);`;

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/validGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/validGraphs.ts
@@ -1,21 +1,17 @@
-export const validGraph = `import { uniqueId } from 'lodash';
-import { Graph, ObjectGraph, Provides } from 'src';
+export const validGraph = `
+import {injectComponent} from 'src';
 
-@Graph()
-export default class SimpleGraph extends ObjectGraph {
-  @Provides()
-  foo(): string {
-    return 'foo';
-  }
+type Own = {
+  name: string;
+};
 
-  @Provides()
-  bar(baz: any): string {
-    return 'foo';
-  }
+type Injected = {
+  bar: Bar;
+};
 
-  @Provides()
-  baz(qux: any): string {
-    return 'baz';
-  }
-}`;
+const _Foo = (props: Own & Injected) => {
+  return null;
+};
+
+export const Foo = injectComponent<Own, Injected>(_Foo, SomeGraph);`;
 

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/validGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/validGraphs.ts
@@ -1,0 +1,21 @@
+export const validGraph = `import { uniqueId } from 'lodash';
+import { Graph, ObjectGraph, Provides } from 'src';
+
+@Graph()
+export default class SimpleGraph extends ObjectGraph {
+  @Provides()
+  foo(): string {
+    return 'foo';
+  }
+
+  @Provides()
+  bar(baz: any): string {
+    return 'foo';
+  }
+
+  @Provides()
+  baz(qux: any): string {
+    return 'baz';
+  }
+}`;
+

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/validGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/validGraphs.ts
@@ -22,7 +22,7 @@ const _Foo = () => {
   return null;
 };
 
-export const Foo = injectComponent<Own, Injected>(_Foo, SomeGraph);`;
+export const Foo = injectComponent(_Foo, SomeGraph);`;
 
 export const validGraphWithOwnProps = `
 import {injectComponent} from 'src';
@@ -58,4 +58,12 @@ const _Foo = (props: any) => {
 };
 
 export const Foo = injectComponent(_Foo, SomeGraph);`;
+
+export const validGraphWithInlineTypes = `
+const Component = ({ computedFromProps }: DependenciesOf<LifecycleBoundGraph, 'computedFromProps'>) => {
+  return null;
+};
+
+const InjectedComponent = injectComponent<{ stringFromProps: string }>(Component, LifecycleBoundGraph);
+`;
 

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/validGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/validGraphs.ts
@@ -50,3 +50,12 @@ const _Foo = (props: Injected) => {
 
 export const Foo = injectComponent(_Foo, SomeGraph);`;
 
+export const validGraphWithUntypedProps = `
+import {injectComponent} from 'src';
+
+const _Foo = (props: any) => {
+  return null;
+};
+
+export const Foo = injectComponent(_Foo, SomeGraph);`;
+

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/validGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/validGraphs.ts
@@ -24,3 +24,15 @@ const _Foo = () => {
 
 export const Foo = injectComponent<Own, Injected>(_Foo, SomeGraph);`;
 
+export const validGraphWithOwnProps = `
+import {injectComponent} from 'src';
+
+type Own = {
+  name: string;
+};
+
+const _Foo = (props: Own) => {
+  return null;
+};
+
+export const Foo = injectComponent<Own>(_Foo, SomeGraph);`;

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/validGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/validGraphs.ts
@@ -36,3 +36,17 @@ const _Foo = (props: Own) => {
 };
 
 export const Foo = injectComponent<Own>(_Foo, SomeGraph);`;
+
+export const validGraphWithInjectedProps = `
+import {injectComponent} from 'src';
+
+type Injected = {
+  name: string;
+};
+
+const _Foo = (props: Injected) => {
+  return null;
+};
+
+export const Foo = injectComponent(_Foo, SomeGraph);`;
+

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/validGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/code/validGraphs.ts
@@ -15,3 +15,12 @@ const _Foo = (props: Own & Injected) => {
 
 export const Foo = injectComponent<Own, Injected>(_Foo, SomeGraph);`;
 
+export const validGraphWithoutProps = `
+import {injectComponent} from 'src';
+
+const _Foo = () => {
+  return null;
+};
+
+export const Foo = injectComponent<Own, Injected>(_Foo, SomeGraph);`;
+

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/stronglyTypedInjectComponent.test.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/stronglyTypedInjectComponent.test.ts
@@ -3,6 +3,7 @@ import { stronglyTypedInjectComponentGenerator } from '../../src/rules/stronglyT
 import {
   validGraph,
   validGraphWithInjectedProps,
+  validGraphWithInlineTypes,
   validGraphWithoutProps,
   validGraphWithOwnProps,
   validGraphWithUntypedProps,
@@ -25,6 +26,7 @@ ruleTester.run(
       validGraphWithOwnProps,
       validGraphWithInjectedProps,
       validGraphWithUntypedProps,
+      validGraphWithInlineTypes,
     ],
     invalid: [
       {

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/stronglyTypedInjectComponent.test.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/stronglyTypedInjectComponent.test.ts
@@ -1,0 +1,21 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { stronglyTypedInjectComponentGenerator } from '../../src/rules/stronglyTypedInjectComponent';
+import { validGraph } from './code/validGraphs';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run(
+  'no-circular-dependencies',
+  stronglyTypedInjectComponentGenerator(),
+  {
+    valid: [
+      validGraph,
+    ],
+    invalid: [
+      // {
+      //   code: invalidGraph,
+      //   errors: [{ messageId: 'strongly-typed-inject-component' }],
+      // },
+    ],
+  },
+);

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/stronglyTypedInjectComponent.test.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/stronglyTypedInjectComponent.test.ts
@@ -1,7 +1,11 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { stronglyTypedInjectComponentGenerator } from '../../src/rules/stronglyTypedInjectComponent';
-import { validGraph, validGraphWithoutProps } from './code/validGraphs';
-import { invalidGraph } from './code/invalidGraphs';
+import { validGraph, validGraphWithoutProps, validGraphWithOwnProps } from './code/validGraphs';
+import {
+invalidGraph,
+invalidGraphOnlyWithOwnProps,
+invalidGraphWithOwnPropsAndUnexpectedInjectedProps,
+} from './code/invalidGraphs';
 
 const ruleTester = new RuleTester();
 
@@ -12,11 +16,19 @@ ruleTester.run(
     valid: [
       validGraph,
       validGraphWithoutProps,
+      validGraphWithOwnProps,
     ],
-    valid1: [],
     invalid: [
       {
         code: invalidGraph,
+        errors: [{ messageId: 'strongly-typed-inject-component' }],
+      },
+      {
+        code: invalidGraphOnlyWithOwnProps,
+        errors: [{ messageId: 'strongly-typed-inject-component' }],
+      },
+      {
+        code: invalidGraphWithOwnPropsAndUnexpectedInjectedProps,
         errors: [{ messageId: 'strongly-typed-inject-component' }],
       },
     ],

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/stronglyTypedInjectComponent.test.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/stronglyTypedInjectComponent.test.ts
@@ -1,15 +1,16 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { stronglyTypedInjectComponentGenerator } from '../../src/rules/stronglyTypedInjectComponent';
 import {
-validGraph,
-validGraphWithInjectedProps,
-validGraphWithoutProps,
-validGraphWithOwnProps,
+  validGraph,
+  validGraphWithInjectedProps,
+  validGraphWithoutProps,
+  validGraphWithOwnProps,
+  validGraphWithUntypedProps,
 } from './code/validGraphs';
 import {
-invalidGraph,
-invalidGraphOnlyWithOwnProps,
-invalidGraphWithOwnPropsAndUnexpectedInjectedProps,
+  invalidGraph,
+  invalidGraphOnlyWithOwnProps,
+  invalidGraphWithOwnPropsAndUnexpectedInjectedProps,
 } from './code/invalidGraphs';
 
 const ruleTester = new RuleTester();
@@ -23,6 +24,7 @@ ruleTester.run(
       validGraphWithoutProps,
       validGraphWithOwnProps,
       validGraphWithInjectedProps,
+      validGraphWithUntypedProps,
     ],
     invalid: [
       {

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/stronglyTypedInjectComponent.test.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/stronglyTypedInjectComponent.test.ts
@@ -1,6 +1,11 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { stronglyTypedInjectComponentGenerator } from '../../src/rules/stronglyTypedInjectComponent';
-import { validGraph, validGraphWithoutProps, validGraphWithOwnProps } from './code/validGraphs';
+import {
+validGraph,
+validGraphWithInjectedProps,
+validGraphWithoutProps,
+validGraphWithOwnProps,
+} from './code/validGraphs';
 import {
 invalidGraph,
 invalidGraphOnlyWithOwnProps,
@@ -17,6 +22,7 @@ ruleTester.run(
       validGraph,
       validGraphWithoutProps,
       validGraphWithOwnProps,
+      validGraphWithInjectedProps,
     ],
     invalid: [
       {

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/stronglyTypedInjectComponent.test.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/stronglyTypedInjectComponent.test.ts
@@ -1,6 +1,7 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { stronglyTypedInjectComponentGenerator } from '../../src/rules/stronglyTypedInjectComponent';
-import { validGraph } from './code/validGraphs';
+import { validGraph, validGraphWithoutProps } from './code/validGraphs';
+import { invalidGraph } from './code/invalidGraphs';
 
 const ruleTester = new RuleTester();
 
@@ -10,12 +11,14 @@ ruleTester.run(
   {
     valid: [
       validGraph,
+      validGraphWithoutProps,
     ],
+    valid1: [],
     invalid: [
-      // {
-      //   code: invalidGraph,
-      //   errors: [{ messageId: 'strongly-typed-inject-component' }],
-      // },
+      {
+        code: invalidGraph,
+        errors: [{ messageId: 'strongly-typed-inject-component' }],
+      },
     ],
   },
 );

--- a/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/stronglyTypedInjectComponent.test.ts
+++ b/packages/eslint-plugin-obsidian/tests/stronglyTypedInjectComponent/stronglyTypedInjectComponent.test.ts
@@ -5,7 +5,7 @@ import { validGraph } from './code/validGraphs';
 const ruleTester = new RuleTester();
 
 ruleTester.run(
-  'no-circular-dependencies',
+  'strongly-typed-inject-component',
   stronglyTypedInjectComponentGenerator(),
   {
     valid: [

--- a/packages/eslint-plugin-obsidian/tsconfig.json
+++ b/packages/eslint-plugin-obsidian/tsconfig.json
@@ -2,7 +2,7 @@
   "include": [
     "src/**/*",
     "tests/**/*",
-    ".eslintrc.js", "src/ast", "src/dto", "src/framework", "src/utils", "src/index.ts", "src/types.ts",
+    ".eslintrc.js",
   ],
   "exclude": [
     "node_modules",

--- a/packages/react-obsidian/.eslintrc.json
+++ b/packages/react-obsidian/.eslintrc.json
@@ -31,6 +31,7 @@
       "no-console":"off",
       "obsidian/unresolved-provider-dependencies": "error",
       "obsidian/no-circular-dependencies": "warn",
+      "obsidian/strongly-typed-inject-component": "error",
       "@stylistic/max-len": [
         "error",
         {

--- a/packages/react-obsidian/test/fixtures/InjectedComponent.tsx
+++ b/packages/react-obsidian/test/fixtures/InjectedComponent.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { injectComponent } from '../../src';
 import MainGraph from './MainGraph';
 
-interface InjectedComponentProps {
+interface Injected {
   someString: string;
   stringFromSubgraph: string;
 }
 
-const InjectedComponent = ({ someString, stringFromSubgraph }: InjectedComponentProps) => (
+const InjectedComponent = ({ someString, stringFromSubgraph }: Injected) => (
   <>
     {`${someString}${stringFromSubgraph}`}
   </>

--- a/packages/react-obsidian/test/integration/functionalComponentReactLifecycle.test.tsx
+++ b/packages/react-obsidian/test/integration/functionalComponentReactLifecycle.test.tsx
@@ -32,6 +32,7 @@ describe('React lifecycle - functional component', () => {
   let InjectedComponent: React.FunctionComponent<Partial<InjectedComponentProps>>;
 
   beforeEach(() => {
+    // eslint-disable-next-line obsidian/strongly-typed-inject-component
     InjectedComponent = injectComponent(Component, MainGraph);
   });
 

--- a/packages/react-obsidian/test/integration/resolvePrecedance.test.tsx
+++ b/packages/react-obsidian/test/integration/resolvePrecedance.test.tsx
@@ -6,20 +6,20 @@ import injectedValues from '../fixtures/injectedValues';
 import MainGraph from '../fixtures/MainGraph';
 import ThrowingMainGraph from '../fixtures/ThrowingMainGraph';
 
-interface InjectedComponentProps {
+interface Injected {
   someString: string;
   stringFromSubgraph: string;
 }
 
-const Component: React.FunctionComponent<InjectedComponentProps> = ({
+const Component: React.FunctionComponent<Injected> = ({
   someString,
   stringFromSubgraph,
-}: InjectedComponentProps) => {
+}: Injected) => {
   return <>{someString + stringFromSubgraph}</>;
 };
 
 describe('Property resolving precedence', () => {
-  let InjectedComponent: React.FunctionComponent<Partial<InjectedComponentProps>>;
+  let InjectedComponent: React.FunctionComponent<Partial<Injected>>;
 
   beforeEach(() => {
     InjectedComponent = injectComponent(Component, MainGraph);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8335,6 +8335,7 @@ __metadata:
     typescript: ^4.5.4
   peerDependencies:
     eslint: 8.x.x
+    eslint-plugin-obsidian: "*"
     react-obsidian: 2.x.x
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This PR introduces a new ESLint rule: `strongly-typed-inject-component`. The new rule ensures that functional components that are injected with the `injectComponent` HOC, are strongly typed.

<table>
<tr>
<td> Incorrect </td> <td> Correct </td>
</tr>
<tr>
<td>

```ts
import {injectComponent} from 'react-obsidian';

type Own = {
  name: string;
};

type Injected = {
  bar: Bar;
};

const _Foo = (props: Own & Injected) => {
  return null;
};

export const Foo = injectComponent(_Foo, SomeGraph);
```

</td>
<td>
    
```ts
import {injectComponent} from 'react-obsidian';

type Own = {
  name: string;
};

type Injected = {
  bar: Bar;
};

const _Foo = (props: Own & Injected) => {
  return null;
};

// The rule enforces the correct types are passed to the injectComponent HOC
export const Foo = injectComponent<Own, Injected>(_Foo, SomeGraph);
```

</td>
</tr>
</table>
