### PR TITLE
Fix error reporting in strongly-typed-inject-component ESLint rule

### DIFF
--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/index.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/index.ts
@@ -6,6 +6,7 @@ import {Context} from '../../dto/context';
 export type Options = readonly [
   {
     injectedPropsPattern: string;
+    ownPropsPattern: string;
   },
 ];
 
@@ -39,12 +40,22 @@ export const stronglyTypedInjectComponentGenerator = () => {
           },
           additionalProperties: false,
         },
+        {
+          type: 'object',
+          properties: {
+            ownPropsPattern: {
+              type: 'string',
+            },
+          },
+          additionalProperties: false,
+        },
       ],
       type: 'problem',
     },
     defaultOptions: [
       {
         injectedPropsPattern: '/\\b(Injected|InjectedProps)\\b/',
+        ownPropsPattern: '/\\b(Own|Props|OwnProps)\\b/',
       },
     ],
   }) satisfies Rule;

--- a/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/result/missingTypeError.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/stronglyTypedInjectComponent/result/missingTypeError.ts
@@ -1,12 +1,18 @@
-import type { Type } from '../../../dto/types/type';
 import type { Result } from './result';
 
 export class MissingTypeError implements Result {
   readonly isError = true;
 
-  constructor(private readonly missingTypes: Type[]) { }
+  constructor(private readonly own: string[], private readonly injected: string[]) { }
 
   getMessage() {
-    return `The call to injectComponent is missing prop types. It should be typed as: injectComponent<${this.missingTypes.map(t => t.toString()).join(', ')}> `;
+    console.log(this.getGenerics());
+    return `The call to injectComponent is missing prop types. It should be typed as: injectComponent<${this.getGenerics()}> `;
+  }
+
+  private getGenerics(): string {
+    const own = this.own[0];
+    const injected = this.injected[0];
+    return own && injected ? `${own}, ${injected}` : own;
   }
 }


### PR DESCRIPTION
This PR fixes minor issues in the error reporting of strongly-typed-inject-component ESLint rule.
1. Fix the order of types to print `Own` types before `Injected`
2. Improve edge case handling