### PR TITLE
Introduce lifecycle scopes

### DIFF
--- a/packages/react-obsidian/src/decorators/LifecycleBound.ts
+++ b/packages/react-obsidian/src/decorators/LifecycleBound.ts
@@ -1,6 +1,11 @@
-export function LifecycleBound() {
+type Options = {
+  scope?: 'component' | 'feature';
+};
+
+export function LifecycleBound(options?: Options) {
   return (constructor: any) => {
     Reflect.defineMetadata('isLifecycleBound', true, constructor);
+    Reflect.defineMetadata('lifecycleScope', options?.scope ?? 'feature', constructor);
     return constructor;
   };
 }

--- a/packages/react-obsidian/src/injectors/components/ComponentInjector.tsx
+++ b/packages/react-obsidian/src/injectors/components/ComponentInjector.tsx
@@ -5,6 +5,8 @@ import PropsInjector from './PropsInjector';
 import useGraph from './useGraph';
 import { Constructable } from '../../types';
 import { genericMemo, isMemoizedComponent } from '../../utils/React';
+import { GraphContext } from './graphContext';
+import { useInjectionToken } from './useInjectionToken';
 
 export default class ComponentInjector {
   inject<P>(
@@ -25,10 +27,15 @@ export default class ComponentInjector {
     const compare = isMemoized ? InjectionCandidate.compare : undefined;
 
     return genericMemo((passedProps: P) => {
-      const graph = useGraph<P>(Graph, Target, passedProps);
+      const injectionToken = useInjectionToken(Graph);
+      const graph = useGraph<P>(Graph, Target, passedProps, injectionToken);
       const proxiedProps = new PropsInjector(graph).inject(passedProps);
 
-      return <>{Target(proxiedProps as unknown as PropsWithChildren<P>)}</>;
+      return (
+        <GraphContext.Provider value={{injectionToken}}>
+          {Target(proxiedProps as unknown as PropsWithChildren<P>)}
+        </GraphContext.Provider>
+      );
     }, compare);
   }
 }

--- a/packages/react-obsidian/src/injectors/components/graphContext.ts
+++ b/packages/react-obsidian/src/injectors/components/graphContext.ts
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+interface Context {
+  injectionToken: string;
+}
+
+export const GraphContext = createContext<Context | undefined>(undefined);

--- a/packages/react-obsidian/src/injectors/components/useGraph.ts
+++ b/packages/react-obsidian/src/injectors/components/useGraph.ts
@@ -4,9 +4,15 @@ import { ObjectGraph } from '../../graph/ObjectGraph';
 import graphRegistry from '../../graph/registry/GraphRegistry';
 import referenceCounter from '../../ReferenceCounter';
 
-export default <P>(Graph: Constructable<ObjectGraph>, target: any, props?: Partial<P>) => {
+export default <P>(
+  Graph: Constructable<ObjectGraph>,
+  target: any,
+  props?: Partial<P>,
+  injectionToken?: string,
+) => {
+
   const [graph] = useState(() => {
-    const resolvedGraph = graphRegistry.resolve(Graph, 'lifecycleOwner', props);
+    const resolvedGraph = graphRegistry.resolve(Graph, 'lifecycleOwner', props, injectionToken);
     resolvedGraph.onBind(target);
     return resolvedGraph;
   });

--- a/packages/react-obsidian/src/injectors/components/useInjectionToken.ts
+++ b/packages/react-obsidian/src/injectors/components/useInjectionToken.ts
@@ -1,0 +1,10 @@
+import { useContext, useState } from 'react';
+import { GraphContext } from './graphContext';
+import type { Constructable, ObjectGraph } from '../..';
+import { uniqueId } from '../../utils/uniqueId';
+
+export const useInjectionToken = (Graph: Constructable<ObjectGraph>) => {
+  const ctx = useContext(GraphContext);
+  const [injectionToken] = useState(() => ctx?.injectionToken ?? uniqueId(Graph.name));
+  return injectionToken;
+};

--- a/packages/react-obsidian/test/integration/scopedLifecycleBoundGraphs.test.tsx
+++ b/packages/react-obsidian/test/integration/scopedLifecycleBoundGraphs.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import {
+  Graph,
+  injectComponent,
+  LifecycleBound,
+  ObjectGraph,
+  Provides,
+  type DependenciesOf,
+} from '../../src';
+
+let instanceCounter = 0;
+
+describe('Scoped lifecycle bound graphs', () => {
+  beforeEach(() => {
+    instanceCounter = 0;
+  });
+
+  it('reuses the same graph instance when injecting child components', () => {
+    const resultA = render(<ComponentA count={1} />);
+    const resultB = render(<ComponentA count={2} />);
+
+    expect(resultA.container.textContent).toBe('count: 1 id: id1');
+    expect(resultB.container.textContent).toBe('count: 2 id: id2');
+  });
+
+  it('reuses the same graph instance when rendering conditional components', () => {
+    render(<ComponentA count={1} />);
+    const resultA = render(<ComponentA count={2} />);
+    render(<ComponentA count={3} />);
+
+    resultA.rerender(<ComponentA count={2} renderComponentC />);
+    expect(resultA.container.textContent).toEqual('count: 2 id: id2 from C: count: 2 id: id2');
+  });
+});
+
+@LifecycleBound({ scope: 'component' }) @Graph()
+class ScopedLifecycleBoundGraph extends ObjectGraph {
+  private instanceId: string;
+
+  constructor(private props: Props) {
+    super(props);
+    this.instanceId = `id${++instanceCounter}`;
+  }
+
+  @Provides()
+  count() {
+    return this.props.count;
+  }
+
+  @Provides()
+  id() {
+    return this.instanceId;
+  }
+}
+
+type Props = {
+  count: number;
+  injectionToken?: string;
+  renderComponentC?: boolean;
+};
+
+const ComponentA = injectComponent<Props>(({renderComponentC, injectionToken}: Props) => {
+  console.log(injectionToken);
+  return (
+    <>
+      <ComponentB />
+      {renderComponentC && <ComponentC />}
+    </>
+  );
+
+}, ScopedLifecycleBoundGraph);
+
+type Injected = DependenciesOf<ScopedLifecycleBoundGraph, 'count' | 'id'>;
+type Own = {injectionToken: string};
+
+const ComponentB = injectComponent(({count, id, injectionToken}: Injected & Own) => {
+  console.log(injectionToken);
+  return <>{`count: ${count} id: ${id}`}</>;
+}, ScopedLifecycleBoundGraph);
+
+const ComponentC = injectComponent(({count, id, injectionToken}: Injected & Own) => {
+  console.log(injectionToken);
+  return <>{` from C: count: ${count} id: ${id}`}</>;
+}, ScopedLifecycleBoundGraph);


### PR DESCRIPTION
### Background
Complex screens that display many components generally tend to have big graphs. In such cases, splitting the graph into multiple smaller subgraphs where each subgraph accompanies a single component can be beneficial. Graphs that are bound to a component should behave slightly differently than graphs that are bound to the lifecycle of a feature. For example, when a component is displayed in multiple screens, a new graph should be created for each component instance.

This PR adds the ability to change the scope of lifecycle-bound graphs to a single component and its direct children.

### API
The `@LifecycleBound` decorator now accepts a new `scope` option. The `scope` option can be set to either `feature` or `component`. The default value is `feature`. When the `scope` option is set to `component`, a new graph is created for each component instance. The same graph is shared between the component and its children.

```ts
import {LifecycleBound, Graph, ObjectGraph} from 'react-obsidian';

@LifecycleBound({ scope: 'component' }) @Graph()
class ScopedLifecycleBoundGraph extends ObjectGraph {
}
```
### Example
First, let's create a graph that is bound to the lifecycle of a component. The graph provides a single dependency `text`.

```tsx
import {LifecycleBound, Graph, ObjectGraph, injectComponent, Provides} from 'react-obsidian';

@LifecycleBound({ scope: 'component' }) @Graph()
class ScopedGraph extends ObjectGraph<ParentProps> {
  constructor(private props: ParentProps) {
    super(props);
  }

  @Provides()
  text() {
    return this.props.text;
  }
}
```

Next, let's create two components that use the graph. The Parent component renders a Child component that's also injected with the `ScopedGraph` we created above.

```tsx
type ParentProps = {
  text: string;
};

const Parent = injectComponent<ParentProps>(() => {
  return <Child />;
}, ScopedLifecycleBoundGraph);

type ChildProps = DependenciesOf<ScopedLifecycleBoundGraph, 'text'>

const Child = injectComponent(({text}: ChildProps) => {
  return <p>{text}</p>;
}, ScopedLifecycleBoundGraph);
```

Finally, let's render the Parent component with different texts.

```tsx
function App() {
  return (
    <div>
      <Parent text="Hello" />
      <Parent text="World" />
    </div>
  );
}
```

When the `scope` option is set to `component`, the `ScopedGraph` is created **twice**, once for each `Parent` component. The `Child` component is injected with the `ScopedGraph` instance that's bound to the `Parent` component.