### PR TITLE
Support registering graphs

### DIFF
--- a/packages/documentation/docs/documentation/usage/ServiceLocator.mdx
+++ b/packages/documentation/docs/documentation/usage/ServiceLocator.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 6
 title: "Service locator"
+tags: [Service Locator]
 ---
 
 ## Obtaining dependencies imperatively

--- a/packages/documentation/docs/reference/mediatorObservable.mdx
+++ b/packages/documentation/docs/reference/mediatorObservable.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 title: 'MediatorObservable'
 tags: [MediatorObservable, Reactivity]
 ---

--- a/packages/documentation/docs/reference/observable.mdx
+++ b/packages/documentation/docs/reference/observable.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 title: 'Observable'
 tags: [Observable, Reactivity]
 ---

--- a/packages/documentation/docs/reference/obsidian.mdx
+++ b/packages/documentation/docs/reference/obsidian.mdx
@@ -1,0 +1,39 @@
+---
+sidebar_position: 1
+title: 'Obsidian'
+---
+
+`Obsidian` **exposes a set of functions that allow you to interact with the Obsidian framework imperatively.**
+
+* [Reference](#reference)
+  * [obtain(keyOrGraph, props?)](#obtainkeyorgraph-props)
+  * [registerGraph(key, graphGenerator)](#registergraphkey-graphgenerator)
+  * [inject(target, keyOrGraph)](#injecttarget-keyorgraph)
+* [Usage](#usage)
+  * [Conditional rendering of a component](#conditional-rendering-of-a-component)
+___
+
+## Reference
+### obtain(keyOrGraph, props?): ServiceLocator
+The `obtain` function is used to obtain a graph instance to be used as a [service locator](https://en.wikipedia.org/wiki/Service_locator_pattern).
+
+#### Arguments
+* `keyOrGraph?` - The class reference of the graph or its corresponding key if it was registered with a key.
+* `props?` - An object containing props to be passed to the graph's constructor if this is the first time the graph is being instantiated.
+
+#### Returns
+* `ServiceLocator` - A service locator instance that can be used to resolve dependencies from the graph.
+
+### registerGraph(key, graphGenerator)
+The `registerGraph` function is used to register a graph generator function with a key. This allows the graph to be instantiated using the key instead of the class reference. This is useful when you want to decouple the graph's instantiation from its usage.
+
+#### Arguments
+* `key` - The key to register the graph with.
+* `graphGenerator` - A function that returns the graph class reference. The generator function is called only when the graph is being instantiated. It's recommended to retrieve the class reference using inline require to delay side effects until the graph is actually used.
+
+### inject(target, keyOrGraph)
+The `inject` function is used to inject dependencies annotated with the `@LateInject` decorator into a class instance. 
+
+#### Arguments
+* `target` - The class instance to inject the dependencies into.
+* `keyOrGraph` - The class reference of the graph or its corresponding key if it was registered with a key.

--- a/packages/documentation/docs/reference/obsidian.mdx
+++ b/packages/documentation/docs/reference/obsidian.mdx
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 title: 'Obsidian'
+tags: [Service Locator]
 ---
 
 `Obsidian` **exposes a set of functions that allow you to interact with the Obsidian framework imperatively.**
@@ -9,8 +10,6 @@ title: 'Obsidian'
   * [obtain(keyOrGraph, props?)](#obtainkeyorgraph-props)
   * [registerGraph(key, graphGenerator)](#registergraphkey-graphgenerator)
   * [inject(target, keyOrGraph)](#injecttarget-keyorgraph)
-* [Usage](#usage)
-  * [Conditional rendering of a component](#conditional-rendering-of-a-component)
 ___
 
 ## Reference

--- a/packages/documentation/docs/reference/useObserver.mdx
+++ b/packages/documentation/docs/reference/useObserver.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 title: 'useObserver'
 tags: [useObserver, Reactivity]
 ---

--- a/packages/documentation/docs/reference/useObservers.mdx
+++ b/packages/documentation/docs/reference/useObservers.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: 'useObservers'
 tags: [useObservers, Reactivity]
 ---

--- a/packages/react-obsidian/.eslintrc.json
+++ b/packages/react-obsidian/.eslintrc.json
@@ -39,7 +39,7 @@
           "code": 115,
           "comments": 200,
           "ignoreRegExpLiterals": true,
-          "ignorePattern": "throw new Error\\(.*\\);"
+          "ignorePattern": "throw new Error\\(.*\\);|expect\\(\\(\\) => uut\\.resolve\\('main'\\)\\)\\.toThrow\\(.*\\);"
         }
       ],
       "@stylistic/no-extra-semi": "error",

--- a/packages/react-obsidian/.eslintrc.json
+++ b/packages/react-obsidian/.eslintrc.json
@@ -39,7 +39,7 @@
           "code": 115,
           "comments": 200,
           "ignoreRegExpLiterals": true,
-          "ignorePattern": "throw new Error\\(.*\\);|expect\\(\\(\\) => uut\\.resolve\\('main'\\)\\)\\.toThrow\\(.*\\);"
+          "ignorePattern": "throw new Error\\(.*\\);|expect\\(.*\\)\\.toThrow\\(.*\\);"
         }
       ],
       "@stylistic/no-extra-semi": "error",

--- a/packages/react-obsidian/.eslintrc.json
+++ b/packages/react-obsidian/.eslintrc.json
@@ -28,6 +28,7 @@
         "obsidian"
     ],
     "rules": {
+      "global-require": "off",
       "no-console":"off",
       "obsidian/unresolved-provider-dependencies": "error",
       "obsidian/no-circular-dependencies": "warn",
@@ -37,7 +38,8 @@
         {
           "code": 115,
           "comments": 200,
-          "ignoreRegExpLiterals": true
+          "ignoreRegExpLiterals": true,
+          "ignorePattern": "throw new Error\\(.*\\);"
         }
       ],
       "@stylistic/no-extra-semi": "error",

--- a/packages/react-obsidian/src/Obsidian.ts
+++ b/packages/react-obsidian/src/Obsidian.ts
@@ -17,8 +17,8 @@ export default class Obsidian {
     return serviceLocatorFactory.fromGraph(keyOrGraph, props);
   }
 
-  inject<T extends object>(target: T, graph?: ObjectGraph) {
-    return lateInjector.inject(target, graph);
+  inject<T extends object>(target: T, keyOrGraph?: string | ObjectGraph) {
+    return lateInjector.inject(target, keyOrGraph);
   }
 
   addGraphMiddleware(middleware: GraphMiddleware) {

--- a/packages/react-obsidian/src/Obsidian.ts
+++ b/packages/react-obsidian/src/Obsidian.ts
@@ -1,16 +1,20 @@
 import graphRegistry from './graph/registry/GraphRegistry';
 import { ObjectGraph } from './graph/ObjectGraph';
-import { GraphInternals, ServiceLocator } from './types';
+import { GraphInternals, ServiceLocator, type Constructable } from './types';
 import { GraphMiddleware } from './graph/registry/GraphMiddleware';
 import lateInjector from './injectors/class/LateInjector';
 import serviceLocatorFactory from './graph/ServiceLocatorFactory';
 
 export default class Obsidian {
-  obtain<T extends ObjectGraph<P>, P>(
-    Graph: new(...args: P[]) => T,
+  registerGraph(key: string, generator: () => Constructable<ObjectGraph>) {
+    graphRegistry.registerGraphGenerator(key, generator);
+  }
+
+  obtain<T extends ObjectGraph<P>, P = unknown>(
+    keyOrGraph: string | (new(...args: P[]) => T),
     props?: P,
   ): ServiceLocator<Omit<T, GraphInternals>> {
-    return serviceLocatorFactory.fromGraph(Graph, props);
+    return serviceLocatorFactory.fromGraph(keyOrGraph, props);
   }
 
   inject<T extends object>(target: T, graph?: ObjectGraph) {

--- a/packages/react-obsidian/src/decorators/inject/Injectable.ts
+++ b/packages/react-obsidian/src/decorators/inject/Injectable.ts
@@ -3,6 +3,6 @@ import { Graph } from '../../graph/Graph';
 import graphRegistry from '../../graph/registry/GraphRegistry';
 import ClassInjector from '../../injectors/class/ClassInjector';
 
-export function Injectable(Graph: Constructable<Graph>): any {
-  return new ClassInjector(graphRegistry).inject(Graph);
+export function Injectable(keyOrGraph: string | Constructable<Graph>): any {
+  return new ClassInjector(graphRegistry).inject(keyOrGraph);
 }

--- a/packages/react-obsidian/src/graph/ServiceLocatorFactory.ts
+++ b/packages/react-obsidian/src/graph/ServiceLocatorFactory.ts
@@ -3,8 +3,8 @@ import { Constructable, ServiceLocator as ServiceLocatorType } from '../types';
 import graphRegistry from './registry/GraphRegistry';
 
 export default class ServiceLocatorFactory {
-  static fromGraph<T extends ObjectGraph<P>, P = any>(Graph: Constructable<T>, props?: P) {
-    const resolved = graphRegistry.resolve(Graph, 'serviceLocator', props);
+  static fromGraph<T extends ObjectGraph<P>, P = any>(keyOrGraph: string | Constructable<T>, props?: P) {
+    const resolved = graphRegistry.resolve(keyOrGraph, 'serviceLocator', props);
     const wrapped = new Proxy(resolved, {
       get(_target: any, property: string, receiver: any) {
         return () => resolved.retrieve(property, receiver);

--- a/packages/react-obsidian/src/graph/registry/GraphRegistry.test.ts
+++ b/packages/react-obsidian/src/graph/registry/GraphRegistry.test.ts
@@ -59,4 +59,27 @@ describe('GraphRegistry', () => {
 
     expect(uut.resolve(ScopedLifecycleBoundGraph, 'lifecycleOwner', undefined, 'token')).not.toBe(graph);
   });
+
+  it('resolves graph by key', () => {
+    uut.registerGraphGenerator('main', () => MainGraph);
+    expect(uut.resolve('main')).toBeInstanceOf(MainGraph);
+  });
+
+  it('throws an error when resolving a graph by key that is not registered', () => {
+    expect(() => uut.resolve('main')).toThrow('Attempted to resolve a graph by key "main" that is not registered. Did you forget to call Obsidian.registerGraph?');
+  });
+
+  it('clears graph generators', () => {
+    uut.registerGraphGenerator('main', () => MainGraph);
+    uut.clearAll();
+    expect(() => uut.resolve('main')).toThrow();
+  });
+
+  it('clears graph generator for a specific graph', () => {
+    uut.registerGraphGenerator('main', () => MainGraph);
+    const graph = uut.resolve('main');
+
+    uut.clear(graph);
+    expect(() => uut.resolve('main')).toThrow();
+  });
 });

--- a/packages/react-obsidian/src/graph/registry/GraphRegistry.test.ts
+++ b/packages/react-obsidian/src/graph/registry/GraphRegistry.test.ts
@@ -1,3 +1,4 @@
+import { mock } from 'jest-mock-extended';
 import SingletonGraph from '../../../test/fixtures/SingletonGraph';
 import MainGraph from '../../../test/fixtures/MainGraph';
 import { GraphRegistry } from './GraphRegistry';
@@ -81,5 +82,12 @@ describe('GraphRegistry', () => {
 
     uut.clear(graph);
     expect(() => uut.resolve('main')).toThrow();
+  });
+
+  it('throws when registering a graph generator with the same key', () => {
+    uut.registerGraphGenerator('main', () => mock());
+    expect(
+      () => uut.registerGraphGenerator('main', () => mock()),
+    ).toThrow('Attempted to register a graph generator for key "main" that is already registered.');
   });
 });

--- a/packages/react-obsidian/src/graph/registry/GraphRegistry.ts
+++ b/packages/react-obsidian/src/graph/registry/GraphRegistry.ts
@@ -26,7 +26,9 @@ export class GraphRegistry {
     this.keyToGenerator.set(key, generator);
   }
 
-  ensureRegistered(graph: Graph) {
+  ensureRegistered(keyOrGraph: string | Graph) {
+    if (isString(keyOrGraph)) return;
+    const graph = keyOrGraph;
     if (this.instanceToConstructor.get(graph)) return;
     this.set(graph.constructor as any, graph);
   }

--- a/packages/react-obsidian/src/graph/registry/GraphRegistry.ts
+++ b/packages/react-obsidian/src/graph/registry/GraphRegistry.ts
@@ -4,6 +4,7 @@ import { Middleware } from './Middleware';
 import GraphMiddlewareChain from './GraphMiddlewareChain';
 import { ObtainLifecycleBoundGraphException } from './ObtainLifecycleBoundGraphException';
 import { getGlobal } from '../../utils/getGlobal';
+import { isString } from '../../utils/isString';
 
 export class GraphRegistry {
   private readonly constructorToInstance = new Map<Constructable<Graph>, Set<Graph>>();
@@ -13,9 +14,15 @@ export class GraphRegistry {
   private readonly nameToInstance = new Map<string, Graph>();
   private readonly graphToSubgraphs = new Map<Constructable<Graph>, Set<Constructable<Graph>>>();
   private readonly graphMiddlewares = new GraphMiddlewareChain();
+  private readonly keyToGenerator = new Map<string,() => Constructable<Graph>>();
+  private readonly keyToGraph = new Map<string, Constructable<Graph>>();
 
   register(constructor: Constructable<Graph>, subgraphs: Constructable<Graph>[] = []) {
     this.graphToSubgraphs.set(constructor, new Set(subgraphs));
+  }
+
+  registerGraphGenerator(key: string, generator: () => Constructable<Graph>) {
+    this.keyToGenerator.set(key, generator);
   }
 
   ensureRegistered(graph: Graph) {
@@ -34,12 +41,15 @@ export class GraphRegistry {
   }
 
   resolve<T extends Graph>(
-    Graph: Constructable<T>,
+    keyOrGraph: String | Constructable<T>,
     source: 'lifecycleOwner' | 'classInjection' | 'serviceLocator' = 'lifecycleOwner',
     props: any = undefined,
     injectionToken?: string,
   ): T {
-    if ((this.isSingleton(Graph) || this.isBoundToReactLifecycle(Graph)) && this.has(Graph, injectionToken)) {
+    const Graph = isString(keyOrGraph) ?
+      this.getGraphConstructorByKey<T>(keyOrGraph) :
+      keyOrGraph as Constructable<T>;
+    if (( this.isSingleton(Graph) || this.isBoundToReactLifecycle(Graph)) && this.has(Graph, injectionToken)) {
       return this.isComponentScopedLifecycleBound(Graph) ?
         this.getByInjectionToken(Graph, injectionToken) :
         this.getFirst(Graph);
@@ -50,6 +60,15 @@ export class GraphRegistry {
     const graph = this.graphMiddlewares.resolve(Graph, props);
     this.set(Graph, graph, injectionToken);
     return graph as T;
+  }
+
+  private getGraphConstructorByKey<T extends Graph>(key: string): Constructable<T> {
+    if (this.keyToGraph.has(key)) return this.keyToGraph.get(key) as Constructable<T>;
+    const generator = this.keyToGenerator.get(key);
+    if (!generator) throw new Error(`Attempted to resolve a graph by key "${key}" that is not registered. Did you forget to call Obsidian.registerGraph?`);
+    const constructor = generator();
+    this.keyToGraph.set(key, constructor);
+    return constructor as Constructable<T>;
   }
 
   private has(Graph: Constructable<Graph>, injectionToken?: string): boolean {
@@ -133,6 +152,18 @@ export class GraphRegistry {
       this.injectionTokenToInstance.delete(token);
       this.instanceToInjectionToken.delete(graph);
     }
+
+    this.clearGraphsRegisteredByKey(Graph);
+  }
+
+  private clearGraphsRegisteredByKey(Graph: Constructable<Graph>) {
+    [...this.keyToGraph.keys()]
+      .map((key) => [key, this.keyToGraph.get(key)!] as [string, Constructable<Graph>])
+      .filter(([_, $Graph]) => $Graph === Graph)
+      .forEach(([key, _]) => {
+        this.keyToGraph.delete(key);
+        this.keyToGenerator.delete(key);
+      });
   }
 
   addGraphMiddleware(middleware: Middleware<Graph>) {
@@ -149,6 +180,8 @@ export class GraphRegistry {
     this.nameToInstance.clear();
     this.injectionTokenToInstance.clear();
     this.instanceToInjectionToken.clear();
+    this.keyToGenerator.clear();
+    this.keyToGraph.clear();
   }
 }
 

--- a/packages/react-obsidian/src/graph/registry/GraphRegistry.ts
+++ b/packages/react-obsidian/src/graph/registry/GraphRegistry.ts
@@ -22,6 +22,7 @@ export class GraphRegistry {
   }
 
   registerGraphGenerator(key: string, generator: () => Constructable<Graph>) {
+    if (this.keyToGenerator.has(key)) throw new Error(`Attempted to register a graph generator for key "${key}" that is already registered.`);
     this.keyToGenerator.set(key, generator);
   }
 

--- a/packages/react-obsidian/src/injectors/class/ClassInjector.ts
+++ b/packages/react-obsidian/src/injectors/class/ClassInjector.ts
@@ -11,14 +11,14 @@ export default class ClassInjector {
     private injectionMetadata: InjectionMetadata = new InjectionMetadata(),
   ) {}
 
-  inject(Graph: Constructable<Graph>) {
+  inject(keyOrGraph: string | Constructable<Graph>) {
     return (Target: Constructable<any>) => {
-      return new Proxy(Target, this.createProxyHandler(Graph, this.graphRegistry, this.injectionMetadata));
+      return new Proxy(Target, this.createProxyHandler(keyOrGraph, this.graphRegistry, this.injectionMetadata));
     };
   }
 
   private createProxyHandler(
-    Graph: Constructable<Graph>,
+    keyOrGraph: string | Constructable<Graph>,
     graphRegistry: GraphRegistry,
     injectionMetadata: InjectionMetadata,
   ): ProxyHandler<any> {
@@ -26,7 +26,7 @@ export default class ClassInjector {
       construct(target: any, args: any[], newTarget: Function): any {
         const isReactClassComponent = target.prototype?.isReactComponent;
         const source = isReactClassComponent ? 'lifecycleOwner' : 'classInjection';
-        const graph = graphRegistry.resolve(Graph, source, args.length > 0 ? args[0] : undefined);
+        const graph = graphRegistry.resolve(keyOrGraph, source, args.length > 0 ? args[0] : undefined);
         if (isReactClassComponent) {
           referenceCounter.retain(graph);
         }

--- a/packages/react-obsidian/src/injectors/components/ComponentInjector.tsx
+++ b/packages/react-obsidian/src/injectors/components/ComponentInjector.tsx
@@ -11,24 +11,24 @@ import { useInjectionToken } from './useInjectionToken';
 export default class ComponentInjector {
   inject<P>(
     Target: React.FunctionComponent<P>,
-    Graph: Constructable<ObjectGraph>,
+    keyOrGraph: string | Constructable<ObjectGraph>,
   ): React.FunctionComponent<Partial<P>> {
-    const Wrapped = this.wrapComponent(Target, Graph);
+    const Wrapped = this.wrapComponent(Target, keyOrGraph);
     hoistNonReactStatics(Wrapped, Target);
     return Wrapped;
   }
 
   private wrapComponent<P>(
     InjectionCandidate: React.FunctionComponent<P>,
-    Graph: Constructable<ObjectGraph>,
+    keyOrGraph: string | Constructable<ObjectGraph>,
   ): React.FunctionComponent<Partial<P>> {
     const isMemoized = isMemoizedComponent(InjectionCandidate);
     const Target = isMemoized ? InjectionCandidate.type : InjectionCandidate;
     const compare = isMemoized ? InjectionCandidate.compare : undefined;
 
     return genericMemo((passedProps: P) => {
-      const injectionToken = useInjectionToken(Graph);
-      const graph = useGraph<P>(Graph, Target, passedProps, injectionToken);
+      const injectionToken = useInjectionToken(keyOrGraph);
+      const graph = useGraph<P>(keyOrGraph, Target, passedProps, injectionToken);
       const proxiedProps = new PropsInjector(graph).inject(passedProps);
 
       return (

--- a/packages/react-obsidian/src/injectors/components/InjectComponent.test.tsx
+++ b/packages/react-obsidian/src/injectors/components/InjectComponent.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import type { Constructable, ObjectGraph } from 'src';
+import { Obsidian, type Constructable, type ObjectGraph } from '../..';
 import MainGraph, { Dependencies } from '../../../test/fixtures/MainGraph';
 import { injectComponent } from './InjectComponent';
 
@@ -35,7 +35,6 @@ describe('injectComponent', () => {
     expect(container.textContent).toBe('error: own prop not provided - Fear kills progress');
   });
 
-  // it throws an error if the Graph is undefined
   it('Throws an error if the Graph is undefined', () => {
     const Graph = undefined as unknown as Constructable<ObjectGraph>;
     expect(() => injectComponent(component, Graph)).toThrowError(
@@ -44,5 +43,12 @@ describe('injectComponent', () => {
       + `It's typically caused by circular dependencies.`
       + ` Check the implementation of component.`,
     );
+  });
+
+  it('Injects component by registered graph key', () => {
+    Obsidian.registerGraph('MainGraph', () => MainGraph);
+    const InjectedComponent = injectComponent(component, 'MainGraph');
+    const { container } = render(<InjectedComponent />);
+    expect(container.textContent).toBe('error: own prop not provided - Fear kills progress');
   });
 });

--- a/packages/react-obsidian/src/injectors/components/InjectComponent.ts
+++ b/packages/react-obsidian/src/injectors/components/InjectComponent.ts
@@ -1,5 +1,6 @@
 import { ObjectGraph } from '../../graph/ObjectGraph';
 import { Constructable } from '../../types';
+import { isString } from '../../utils/isString';
 import ComponentInjector from './ComponentInjector';
 
 interface Discriminator {
@@ -13,18 +14,18 @@ export const injectComponent = <OwnProps = Discriminator, InjectedProps = Discri
   (OwnProps extends infer P ? OwnProps extends Discriminator ? P : OwnProps : never) &
   (InjectedProps extends Discriminator ? any : InjectedProps)
   >,
-  Graph: Constructable<ObjectGraph>,
+  keyOrGraph: string | Constructable<ObjectGraph>,
 ) => {
-  assertGraph(Graph, Target);
+  assertGraph(keyOrGraph, Target);
 
-  return componentInjector.inject(Target, Graph) as React.FunctionComponent<
+  return componentInjector.inject(Target, keyOrGraph) as React.FunctionComponent<
   InjectedProps extends Discriminator ?
     OwnProps extends Discriminator ? Partial<OwnProps> : OwnProps :
     OwnProps extends InjectedProps ? Partial<OwnProps> : OwnProps & Partial<InjectedProps>
   >;
 };
-function assertGraph(Graph: Constructable<ObjectGraph<unknown>>, Target: any) {
-  if (!Graph) {
+function assertGraph(keyOrGraph: string | Constructable<ObjectGraph>, Target: any) {
+  if (!isString(keyOrGraph) && !keyOrGraph) {
     throw new Error(
       `injectComponent was called with an undefined Graph.`
       + `This is probably not an issue with Obsidian.`

--- a/packages/react-obsidian/src/injectors/components/useGraph.ts
+++ b/packages/react-obsidian/src/injectors/components/useGraph.ts
@@ -5,14 +5,14 @@ import graphRegistry from '../../graph/registry/GraphRegistry';
 import referenceCounter from '../../ReferenceCounter';
 
 export default <P>(
-  Graph: Constructable<ObjectGraph>,
+  keyOrGraph: string | Constructable<ObjectGraph>,
   target: any,
   props?: Partial<P>,
   injectionToken?: string,
 ) => {
 
   const [graph] = useState(() => {
-    const resolvedGraph = graphRegistry.resolve(Graph, 'lifecycleOwner', props, injectionToken);
+    const resolvedGraph = graphRegistry.resolve(keyOrGraph, 'lifecycleOwner', props, injectionToken);
     resolvedGraph.onBind(target);
     return resolvedGraph;
   });

--- a/packages/react-obsidian/src/injectors/components/useInjectionToken.ts
+++ b/packages/react-obsidian/src/injectors/components/useInjectionToken.ts
@@ -2,9 +2,12 @@ import { useContext, useState } from 'react';
 import { GraphContext } from './graphContext';
 import type { Constructable, ObjectGraph } from '../..';
 import { uniqueId } from '../../utils/uniqueId';
+import { isString } from '../../utils/isString';
 
-export const useInjectionToken = (Graph: Constructable<ObjectGraph>) => {
+export const useInjectionToken = (keyOrGraph: string | Constructable<ObjectGraph>) => {
   const ctx = useContext(GraphContext);
-  const [injectionToken] = useState(() => ctx?.injectionToken ?? uniqueId(Graph.name));
+  const [injectionToken] = useState(() => {
+    return ctx?.injectionToken ?? uniqueId(isString(keyOrGraph)? keyOrGraph : keyOrGraph.name);
+  });
   return injectionToken;
 };

--- a/packages/react-obsidian/src/injectors/hooks/HookInjector.ts
+++ b/packages/react-obsidian/src/injectors/hooks/HookInjector.ts
@@ -6,10 +6,10 @@ import { Constructable } from '../../types';
 export default class HookInjector {
   inject<Args, Result>(
     hook: (args: Args) => Result,
-    Graph: Constructable<ObjectGraph>,
+    keyOrGraph: string | Constructable<ObjectGraph>,
   ): (args?: Partial<Args>) => Result {
     return (args?: Partial<Args>): Result => {
-      const graph = useGraph(Graph, hook, args);
+      const graph = useGraph(keyOrGraph, hook, args);
       return hook(new Proxy(args ?? {}, new Injector(graph)));
     };
   }

--- a/packages/react-obsidian/src/injectors/hooks/InjectHook.test.ts
+++ b/packages/react-obsidian/src/injectors/hooks/InjectHook.test.ts
@@ -3,6 +3,7 @@ import MainGraph from '../../../test/fixtures/MainGraph';
 import Subgraph from '../../../test/fixtures/Subgraph';
 import { DependenciesOf } from '../../types';
 import { injectHook, injectHookWithArguments } from './InjectHook';
+import { Obsidian } from '../..';
 
 describe('injectHook', () => {
   type InjectedProps = DependenciesOf<[MainGraph, Subgraph]>;
@@ -37,11 +38,25 @@ describe('injectHook', () => {
       const { result } = renderHook(injectedHook, { initialProps: { ownProp: expectedResult.ownProp } });
       expect(result.current).toStrictEqual(expectedResult);
     });
+
+    it('injects hook from a registered graph', () => {
+      Obsidian.registerGraph('mainGraph', () => MainGraph);
+      const injectedHook = injectHook<InjectedProps & OwnProps, Result>(hook, 'mainGraph');
+      const { result } = renderHook(injectedHook, { initialProps: { ownProp: expectedResult.ownProp } });
+        expect(result.current).toStrictEqual(expectedResult);
+    });
   });
 
   describe('injectHookWithArguments', () => {
     it('Generics defined', () => {
       const injectedHook = injectHookWithArguments<InjectedProps, OwnProps>(hook, MainGraph);
+      const { result } = renderHook(injectedHook, { initialProps: { ownProp: expectedResult.ownProp } });
+      expect(result.current).toStrictEqual(expectedResult);
+    });
+
+    it('injects hook from a registered graph', () => {
+      Obsidian.registerGraph('mainGraph', () => MainGraph);
+      const injectedHook = injectHookWithArguments<InjectedProps, OwnProps>(hook, 'mainGraph');
       const { result } = renderHook(injectedHook, { initialProps: { ownProp: expectedResult.ownProp } });
       expect(result.current).toStrictEqual(expectedResult);
     });

--- a/packages/react-obsidian/src/injectors/hooks/InjectHook.ts
+++ b/packages/react-obsidian/src/injectors/hooks/InjectHook.ts
@@ -12,14 +12,14 @@ const hookInjector = new HookInjector();
 
 export function injectHookWithArguments<Injected, Own, Result = {}>(
   hook: (args: Injected & Own) => Result,
-  Graph: Constructable<ObjectGraph>,
+  keyOrGraph: string | Constructable<ObjectGraph>,
 ): (props: Own & Partial<Injected>) => Result {
-  return hookInjector.inject(hook, Graph) as (props: Own & Partial<Injected>) => Result;
+  return hookInjector.inject(hook, keyOrGraph) as (props: Own & Partial<Injected>) => Result;
 }
 
 export function injectHook<Injected, Result = {}>(
   hook: (args: Injected) => Result,
-  Graph: Constructable<ObjectGraph>,
+  keyOrGraph: string | Constructable<ObjectGraph>,
 ): (props?: Partial<Injected>) => Result {
-  return hookInjector.inject(hook, Graph);
+  return hookInjector.inject(hook, keyOrGraph);
 }

--- a/packages/react-obsidian/src/utils/isString.ts
+++ b/packages/react-obsidian/src/utils/isString.ts
@@ -1,0 +1,3 @@
+export function isString(value: any): value is string {
+  return typeof value === 'string';
+}

--- a/packages/react-obsidian/test/acceptance/lateInject.test.ts
+++ b/packages/react-obsidian/test/acceptance/lateInject.test.ts
@@ -37,6 +37,32 @@ describe('Late inject', () => {
 
     expect(new Injected().graphString).toBe('from mocked main from mocked subgraph');
   });
+
+  it('injects using a registered graph key', () => {
+    Obsidian.registerGraph('main', () => MainGraph);
+
+    class Injected {
+      @LateInject() graphString!: string;
+
+      constructor() {
+        Obsidian.inject(this, 'main');
+      }
+    }
+
+    expect(new Injected().graphString).toBe('from main from subgraph');
+  });
+
+  it('throws an error if the graph is not registered', () => {
+    class Injected {
+      @LateInject() graphString!: string;
+
+      constructor() {
+        Obsidian.inject(this, 'main');
+      }
+    }
+
+    expect(() => new Injected()).toThrow('Attempted to resolve a graph by key "main" that is not registered. Did you forget to call Obsidian.registerGraph?');
+  });
 });
 
 @Graph()

--- a/packages/react-obsidian/test/acceptance/obtain.test.ts
+++ b/packages/react-obsidian/test/acceptance/obtain.test.ts
@@ -32,4 +32,9 @@ describe('obtain', () => {
       /Could not resolve dep1 from CircularDependencyFromSubgraph\d because of a circular dependency: dep1 -> dep2 -> dep3 -> dep2/,
     );
   });
+
+  it('should be able to obtain a graph by key', () => {
+    Obsidian.registerGraph('MainGraph', () => require('../fixtures/MainGraph').default);
+    expect(Obsidian.obtain<MainGraph>('MainGraph').someString()).toBe(injectedValues.fromStringProvider);
+  });
 });

--- a/packages/react-obsidian/test/integration/classInjection.test.tsx
+++ b/packages/react-obsidian/test/integration/classInjection.test.tsx
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '../../src';
+import { Inject, Injectable, Obsidian } from '../../src';
 import { GraphWithOnBind } from '../fixtures/GraphWithOnBind';
 import injectedValues from '../fixtures/injectedValues';
 import MainGraph from '../fixtures/MainGraph';
@@ -36,6 +36,17 @@ describe('Class injection', () => {
   //   expect(uut.someString).toBe(injectedValues.fromStringProvider);
   //   expect(uut.anotherString).toBe(injectedValues.anotherString);
   // });
+
+  it('injects properties from a registered graph', () => {
+    Obsidian.registerGraph('main', () => MainGraph);
+    const uut = new ClassToTestRegisteredGraph();
+    expect(uut.someString).toBe(injectedValues.fromStringProvider);
+  });
+
+  @Injectable('main')
+  class ClassToTestRegisteredGraph {
+    @Inject() public readonly someString!: string;
+  }
 
   @Injectable(GraphWithOnBind)
   class ClassToTestOnBind {


### PR DESCRIPTION
This PR adds a new API that will allow decoupling injection targets from graphs.

## API
### Registering a graph
Registering a graph will let you use it by its registered key.
```ts
Obsidian.registerGraph('FooGraph', () => require('some/path/FooGraph).default);
```

### injectHook
Inject your target with the key used to register the graph.
```ts
export const useFoo = injectHook(useFooHook, 'FooGraph');
```

### Obsidian.obtain
Registered graphs can still be used as service locators.
```ts
import type FooGraph from 'some/path/FooGraph';

Obsidian.obtain<FooGraph>('FooGraph').foo();
```

### Tasks
- [x] obtain registered graphs
- [x] inject hooks
- [x] inject components
- [x] late inject
- [x] `@Injectable(key)`
- [ ] ~registered subgraphs~ [**ON HOLD:** breaks the `unresolved dependencies` ESLint rule]
- [x] documentation