### PR TITLE
Look for dependencies in super class

### DIFF
--- a/packages/eslint-plugin-obsidian/src/dto/class.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/class.ts
@@ -3,6 +3,7 @@ import { Decorator } from './decorator';
 import { assertDefined } from '../utils/assertions';
 import { isMethodDefinition } from '../utils/ast';
 import { Method } from './method';
+import { Identifier } from './identifier';
 
 export class Clazz {
   constructor(public node: TSESTree.ClassDeclaration) {
@@ -19,6 +20,10 @@ export class Clazz {
     return (this.node.decorators ?? []).map((decorator: TSESTree.Decorator) => {
       return new Decorator(decorator);
     });
+  }
+
+  get superClass() {
+    return this.node.superClass && new Identifier(this.node.superClass).name;
   }
 
   get body() {
@@ -40,7 +45,7 @@ export class Clazz {
     return decorator;
   }
 
-  private get name() {
+  public get name() {
     return this.node.id?.name;
   }
 }

--- a/packages/eslint-plugin-obsidian/src/dto/classFile.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/classFile.ts
@@ -8,4 +8,8 @@ export class ClassFile {
     public readonly imports: Import[],
     public readonly path: string,
   ) {}
+
+  get superClass() {
+    return this.clazz.superClass;
+  }
 }

--- a/packages/eslint-plugin-obsidian/src/dto/file.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/file.ts
@@ -58,7 +58,7 @@ export class File {
   }
 
   findClass(byName: string) {
-    const clazz = this.classes.find((clazz) => clazz.name === byName);
+    const clazz = this.classes.find(($clazz) => $clazz.name === byName);
     return clazz && new ClassFile(clazz, this.imports, this.path);
   }
 

--- a/packages/eslint-plugin-obsidian/src/dto/file.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/file.ts
@@ -57,6 +57,21 @@ export class File {
       }) as Clazz[];
   }
 
+  findClass(byName: string) {
+    const clazz = this.classes.find((clazz) => clazz.name === byName);
+    return clazz && new ClassFile(clazz, this.imports, this.path);
+  }
+
+  private get classes() {
+    return this.body
+      .filter(isClassLike)
+      .map((node) => {
+        const clazz = getClassDeclaration(node);
+        return clazz && new Clazz(clazz);
+      })
+      .filter(Boolean) as Clazz[];
+  }
+
   get variables() {
     return this.body
       .filter(isVariableDeclaration)

--- a/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/classResolver.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/classResolver.ts
@@ -1,0 +1,11 @@
+import type { ClassFile } from "../../dto/classFile";
+import type { FileReader } from "../../framework/fileReader";
+
+export class ClassResolver {
+  constructor(private fileReader: FileReader) { }
+
+  public resolve(clazz: string, from: ClassFile) {
+    const classPath = from.imports.find(($import) => $import.includes(clazz))
+    return classPath && this.fileReader.read(from.path, classPath.path).findClass(clazz);
+  }
+}

--- a/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/classResolver.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/classResolver.ts
@@ -1,11 +1,11 @@
-import type { ClassFile } from "../../dto/classFile";
-import type { FileReader } from "../../framework/fileReader";
+import type { ClassFile } from '../../dto/classFile';
+import type { FileReader } from '../../framework/fileReader';
 
 export class ClassResolver {
   constructor(private fileReader: FileReader) { }
 
   public resolve(clazz: string, from: ClassFile) {
-    const classPath = from.imports.find(($import) => $import.includes(clazz))
+    const classPath = from.imports.find(($import) => $import.includes(clazz));
     return classPath && this.fileReader.read(from.path, classPath.path).findClass(clazz);
   }
 }

--- a/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/createRule.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/createRule.ts
@@ -6,10 +6,14 @@ import { FileReader } from '../../framework/fileReader';
 import { DependencyResolver } from './dependencyResolver';
 import { Import } from '../../dto/import';
 import { SubgraphResolver } from './subgraphResolver';
+import { ClassResolver } from './classResolver';
 
 export function create(context: Context, fileReader: FileReader) {
   const imports: Import[] = [];
-  const dependencyResolver = new DependencyResolver(new SubgraphResolver(fileReader));
+  const dependencyResolver = new DependencyResolver(
+    new SubgraphResolver(fileReader),
+    new ClassResolver(fileReader),
+  );
   const graphHandler = new GraphHandler(context, dependencyResolver);
 
   return {

--- a/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/dependencyResolver.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/dependencyResolver.ts
@@ -3,15 +3,20 @@ import type { Import } from '../../dto/import';
 import type { Clazz } from '../../dto/class';
 import type { SubgraphResolver } from './subgraphResolver';
 import type { Context } from '../../dto/context';
+import type { ClassResolver } from './classResolver';
 
 export class DependencyResolver {
-  constructor(private subgraphResolver: SubgraphResolver) { }
+  constructor(
+    private subgraphResolver: SubgraphResolver,
+    private classResolver: ClassResolver,
+  ) { }
 
   public resolve(context: Context, clazz: Clazz, imports: Import[]) {
     const classWithImports = new ClassFile(clazz, imports, context.currentFilePath);
     return [
       ...this.getGraphDependencies(classWithImports),
       ...this.getDependenciesFromSubgraphs(classWithImports),
+      ...this.getDependenciesFromSuperClass(classWithImports),
     ];
   }
 
@@ -25,5 +30,14 @@ export class DependencyResolver {
     return clazz
       .getDecoratedMethods('Provides')
       .map((method) => method.name);
+  }
+
+  private getDependenciesFromSuperClass(clazz: ClassFile) {
+    if (!clazz.superClass || clazz.superClass === 'ObjectGraph') return [];
+    return this.classResolver
+      .resolve(clazz.superClass, clazz)
+      ?.clazz
+      ?.getDecoratedMethods('Provides')
+      ?.map((method) => method.name) ?? [];
   }
 }

--- a/packages/eslint-plugin-obsidian/tests/stubs/PathResolverStub.ts
+++ b/packages/eslint-plugin-obsidian/tests/stubs/PathResolverStub.ts
@@ -11,6 +11,8 @@ export class PathResolverStub implements PathResolver {
         return `${cwd}/tests/unresolvedProviderDependencies/fixtures/graphWithSubgraph.ts`;
       case './namedExportSubgraph':
         return `${cwd}/tests/unresolvedProviderDependencies/fixtures/namedExportSubgraph.ts`;
+      case './abstractGraph':
+        return `${cwd}/tests/unresolvedProviderDependencies/fixtures/abstractGraph.ts`;
       default:
         throw new Error(`PathResolverStub: Unhandled relativeFilePath: ${relativeFilePath}`);
     }

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/abstractGraph.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/abstractGraph.ts
@@ -1,0 +1,8 @@
+import { ObjectGraph, Provides } from "react-obsidian";
+
+export abstract class AbstractGraph extends ObjectGraph {
+  @Provides()
+  bar(): string {
+    return "bar";
+  }
+}

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/validGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/validGraphs.ts
@@ -110,3 +110,16 @@ export default class SimpleGraph extends ObjectGraph {
     return 'foo';
   }
 }`;
+
+export const validGraphThatExtendsAnotherGraph = `
+import { Graph, ObjectGraph, Provides } from 'src';
+import {AbstractGraph}  from './abstractGraph';
+
+@Graph()
+export default class GraphA extends AbstractGraph {
+  @Provides()
+  foo(bar: string): string {
+    return 'foo' + bar;
+  }
+}
+`;

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/unresolvedDependencies.test.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/unresolvedDependencies.test.ts
@@ -4,6 +4,7 @@ import { PathResolverStub } from '../stubs/PathResolverStub';
 import {
   validFileWithTwoGraphs,
   validGraph,
+  validGraphThatExtendsAnotherGraph,
   validGraphWithNamedExportSubgraph,
   validGraphWithNestedSubgraphs,
   validGraphWithRegularMethod,
@@ -26,6 +27,7 @@ ruleTester.run(
       validGraphWithNamedExportSubgraph,
       validGraphWithRegularMethod,
       validGraphWithNestedSubgraphs,
+      validGraphThatExtendsAnotherGraph,
     ],
     invalid: [
       {


### PR DESCRIPTION
This PR fixes an issue in the unresolved-dependencies ESLint rule. If a graph inherited from another graph, dependencies in the super class were not accounted for.