### PR TITLE
Unresolved dependencies support abstract classes

### DIFF
--- a/packages/eslint-plugin-obsidian/src/dto/class.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/class.ts
@@ -34,6 +34,10 @@ export class Clazz {
     return this.node.body.body;
   }
 
+  public mapDecoratedMethods<T>(decoratorName: string, mapper: (method: Method) => T): T[] {
+    return this.getDecoratedMethods(decoratorName).map(mapper);
+  }
+
   public getDecoratedMethods(decoratorName: string): Method[] {
     return this.body
       .filter(isMethodDefinition)

--- a/packages/eslint-plugin-obsidian/src/dto/class.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/class.ts
@@ -10,6 +10,10 @@ export class Clazz {
     assertDefined(this.node);
   }
 
+  get isAbstract() {
+    return this.node.abstract;
+  }
+
   get decoratorNames() {
     return this.decorators.map((decorator: Decorator) => {
       return decorator.expression.callee.name;

--- a/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/createRule.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/createRule.ts
@@ -11,7 +11,7 @@ import { ClassResolver } from './classResolver';
 export function create(context: Context, fileReader: FileReader) {
   const imports: Import[] = [];
   const dependencyResolver = new DependencyResolver(
-    new SubgraphResolver(fileReader),
+    new SubgraphResolver(fileReader, new ClassResolver(fileReader)),
     new ClassResolver(fileReader),
   );
   const graphHandler = new GraphHandler(context, dependencyResolver);

--- a/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/dependencyResolver.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/dependencyResolver.ts
@@ -27,9 +27,7 @@ export class DependencyResolver {
   }
 
   private getGraphDependencies({ clazz }: ClassFile) {
-    return clazz
-      .getDecoratedMethods('Provides')
-      .map((method) => method.name);
+    return clazz.mapDecoratedMethods('Provides', (method) => method.name) ?? [];
   }
 
   private getDependenciesFromSuperClass(clazz: ClassFile) {
@@ -37,7 +35,6 @@ export class DependencyResolver {
     return this.classResolver
       .resolve(clazz.superClass, clazz)
       ?.clazz
-      ?.getDecoratedMethods('Provides')
-      ?.map((method) => method.name) ?? [];
+      ?.mapDecoratedMethods('Provides', (method) => method.name) ?? [];
   }
 }

--- a/packages/eslint-plugin-obsidian/tests/stubs/PathResolverStub.ts
+++ b/packages/eslint-plugin-obsidian/tests/stubs/PathResolverStub.ts
@@ -13,6 +13,8 @@ export class PathResolverStub implements PathResolver {
         return `${cwd}/tests/unresolvedProviderDependencies/fixtures/namedExportSubgraph.ts`;
       case './abstractGraph':
         return `${cwd}/tests/unresolvedProviderDependencies/fixtures/abstractGraph.ts`;
+      case './graphThatExtendsAnotherGraph':
+        return `${cwd}/tests/unresolvedProviderDependencies/fixtures/graphThatExtendsAnotherGraph.ts`;
       default:
         throw new Error(`PathResolverStub: Unhandled relativeFilePath: ${relativeFilePath}`);
     }

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/graphThatExtendsAnotherGraph.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/graphThatExtendsAnotherGraph.ts
@@ -1,0 +1,10 @@
+import { Graph, Provides } from "react-obsidian";
+import { AbstractGraph } from "./abstractGraph";
+
+@Graph()
+export abstract class GraphThatExtendsAnotherGraph extends AbstractGraph {
+  @Provides()
+  baz(): string {
+    return "baz";
+  }
+}

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/validGraphs.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/fixtures/validGraphs.ts
@@ -123,3 +123,16 @@ export default class GraphA extends AbstractGraph {
   }
 }
 `;
+
+export const validGrapthWithSubgraphThatExtendsAnotherGraph = `
+import { Graph, ObjectGraph, Provides } from 'src';
+import { GraphThatExtendsAnotherGraph } from './graphThatExtendsAnotherGraph';
+
+@Graph({ subgraphs: [GraphThatExtendsAnotherGraph] })
+export default class GraphA extends ObjectGraph {
+  @Provides()
+  foo(bar: string, baz: string): string {
+    return 'foo' + bar + baz;
+  }
+}
+`;

--- a/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/unresolvedDependencies.test.ts
+++ b/packages/eslint-plugin-obsidian/tests/unresolvedProviderDependencies/unresolvedDependencies.test.ts
@@ -9,6 +9,7 @@ import {
   validGraphWithNestedSubgraphs,
   validGraphWithRegularMethod,
   validGraphWithSubgraph,
+  validGrapthWithSubgraphThatExtendsAnotherGraph,
   validLifecycleBoundGraphWithSubgraph,
 } from './fixtures/validGraphs';
 import { invalidGraph } from './fixtures/invalidGraphs';
@@ -28,6 +29,7 @@ ruleTester.run(
       validGraphWithRegularMethod,
       validGraphWithNestedSubgraphs,
       validGraphThatExtendsAnotherGraph,
+      validGrapthWithSubgraphThatExtendsAnotherGraph,
     ],
     invalid: [
       {


### PR DESCRIPTION
Fix an edge case in the unresolved dependencies ESLint rule where it failed to detect dependencies provided by abstract graphs.