### PR TITLE
Fix named injection

### DIFF
--- a/packages/react-obsidian/transformers/babel-plugin-obsidian/__snapshots__/index.test.ts.snap
+++ b/packages/react-obsidian/transformers/babel-plugin-obsidian/__snapshots__/index.test.ts.snap
@@ -59,30 +59,30 @@ let MainGraph = (_dec = Provides({
 
 exports[`Provider Arguments Transformer Does not add property name to @Inject if name is provided by the user 1`] = `
 "var _dec, _class, _descriptor;
-function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object.keys(descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; if ('value' in desc || desc.initializer) { desc.writable = true; } desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object.defineProperty(target, property, desc); desc = null; } return desc; }
-function _initializerWarningHelper(descriptor, context) { throw new Error('Decorating class property failed. Please ensure that ' + 'transform-class-properties is enabled and runs after the decorators transform.'); }
-let MainGraph = (_dec = Inject("someString"), (_class = class MainGraph {
+function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
+function _initializerWarningHelper(r, e) { throw Error("Decorating class property failed. Please ensure that transform-class-properties is enabled and runs after the decorators transform."); }
+let MainGraph = (_dec = Inject('myDependency'), _class = class MainGraph {
   someString = _initializerWarningHelper(_descriptor, this);
-}, (_descriptor = _applyDecoratedDescriptor(_class.prototype, "someString", [_dec], {
+}, _descriptor = _applyDecoratedDescriptor(_class.prototype, "someString", [_dec], {
   configurable: true,
   enumerable: true,
   writable: true,
   initializer: null
-})), _class));"
+}), _class);"
 `;
 
 exports[`Provider Arguments Transformer Does not add property name to @LateInject if name is provided by the user 1`] = `
 "var _dec, _class, _descriptor;
-function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object.keys(descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; if ('value' in desc || desc.initializer) { desc.writable = true; } desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object.defineProperty(target, property, desc); desc = null; } return desc; }
-function _initializerWarningHelper(descriptor, context) { throw new Error('Decorating class property failed. Please ensure that ' + 'transform-class-properties is enabled and runs after the decorators transform.'); }
-let MainGraph = (_dec = LateInject("someString"), (_class = class MainGraph {
+function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
+function _initializerWarningHelper(r, e) { throw Error("Decorating class property failed. Please ensure that transform-class-properties is enabled and runs after the decorators transform."); }
+let MainGraph = (_dec = LateInject('myDependency'), _class = class MainGraph {
   someString = _initializerWarningHelper(_descriptor, this);
-}, (_descriptor = _applyDecoratedDescriptor(_class.prototype, "someString", [_dec], {
+}, _descriptor = _applyDecoratedDescriptor(_class.prototype, "someString", [_dec], {
   configurable: true,
   enumerable: true,
   writable: true,
   initializer: null
-})), _class));"
+}), _class);"
 `;
 
 exports[`Provider Arguments Transformer handles providers that have no arguments 1`] = `

--- a/packages/react-obsidian/transformers/babel-plugin-obsidian/helpers/index.ts
+++ b/packages/react-obsidian/transformers/babel-plugin-obsidian/helpers/index.ts
@@ -9,6 +9,7 @@ import {
   ObjectExpression,
   ObjectPattern,
   TSParameterProperty,
+  type StringLiteral,
 } from '@babel/types';
 
 const never = '';
@@ -16,7 +17,7 @@ const never = '';
 export type AcceptedNodeType = Identifier | TSParameterProperty | ClassProperty;
 
 export function providerIsNotNamed(decorator: Decorator): boolean {
-  const argument = getDecoratorArgument(decorator);
+  const argument = getDecoratorObjectArgument(decorator);
   if (t.isObjectExpression(argument)) {
     return argument.properties.find((p) => {
       if (t.isObjectProperty(p)) {
@@ -29,7 +30,7 @@ export function providerIsNotNamed(decorator: Decorator): boolean {
 }
 
 export function addNameToProviderArguments(node: ClassMethod, decorator: Decorator) {
-  const argument = getDecoratorArgument(decorator) ?? t.objectExpression([]);
+  const argument = getDecoratorObjectArgument(decorator) ?? t.objectExpression([]);
   argument.properties.push(t.objectProperty(
     t.identifier('name'),
     t.stringLiteral(getMethodName(node)),
@@ -37,9 +38,16 @@ export function addNameToProviderArguments(node: ClassMethod, decorator: Decorat
   (decorator.expression as CallExpression).arguments = [argument];
 }
 
-export function getDecoratorArgument(decorator: Decorator): ObjectExpression | undefined {
+export function getDecoratorObjectArgument(decorator: Decorator): ObjectExpression | undefined {
   if (t.isCallExpression(decorator.expression)) {
     return decorator.expression.arguments.find((a) => t.isObjectExpression(a)) as ObjectExpression;
+  }
+  return undefined;
+}
+
+export function getDecoratorStringArgument(decorator: Decorator): StringLiteral | undefined {
+  if (t.isCallExpression(decorator.expression)) {
+    return decorator.expression.arguments.find(a => t.isStringLiteral(a)) as StringLiteral;
   }
   return undefined;
 }

--- a/packages/react-obsidian/transformers/babel-plugin-obsidian/unmagler/property.ts
+++ b/packages/react-obsidian/transformers/babel-plugin-obsidian/unmagler/property.ts
@@ -3,7 +3,7 @@ import {
   getDecoratorName,
   getDecoratorByName,
   passParamNameAsInjectArgument,
-  getDecoratorArgument,
+  getDecoratorStringArgument,
   AcceptedNodeType,
 } from '../helpers';
 
@@ -15,7 +15,7 @@ function savePropertyName(name: string, node: AcceptedNodeType) {
 }
 
 function injectIsNotNamed(decorator: Decorator): boolean {
-  return getDecoratorArgument(decorator) === undefined;
+  return getDecoratorStringArgument(decorator) === undefined;
 }
 
 export default savePropertyName;


### PR DESCRIPTION
When manually passing the injection token to the `@Inject` decorator, it was incorrectly overridden with the property name.

`@Inject('FooToken') foo` was transpiled by mistake as `@Inject('foo') foo`.