### PR TITLE
Deprecate capitalized decorators in favor of lower cased decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ Both functions are annotated by the `@Provides()` annotation. This signals Obsid
 Notice how the `biLogger` function receives an `httpClient` as an argument. This means that `biLogger` is dependent on `httpClient`. Obsidian will create an `httpClient` when `biLogger` is injected. 
 
 ``` typescript
-@Singleton() @Graph()
+@singleton() @graph()
 class ApplicationGraph extends ObjectGraph {
-  @Provides()
+  @provides()
   httpClient(): HttpClient {
     return new HttpClient();
   }
 
-  @Provides()
+  @provides()
   biLogger(httpClient: HttpClient): BiLogger {
     return new BiLogger(httpClient);
   }

--- a/packages/documentation/docs/documentation/documentation.mdx
+++ b/packages/documentation/docs/documentation/documentation.mdx
@@ -18,20 +18,20 @@ Get started by **following the installation guide** bellow. Or **try Obsidian im
 
 Define a singleton graph that is instantiated once and is retained throughout the lifespan of the application. All dependencies it provides are also singletons. The graph bellow provides two dependencies that can be injected: `fooService` and `barManager`.
 ```ts title="A singleton graph that provides two dependencies"
-import {Singleton, Graph, ObjectGraph, Provides} from 'react-obsidian';
+import {singleton, graph, ObjectGraph, provides} from 'react-obsidian';
 
 
-@Singleton() @Graph()
+@singleton() @graph()
 export class ApplicationGraph extends ObjectGraph {
 
  // fooService requires a barManager so it receives one as a parameter.
-  @Provides()
+  @provides()
   fooService(barManager: BarManager): FooService {
     return new FooService(barManager);
   }
 
 
-  @Provides()
+  @provides()
   barManager(): BarManager {
     return new BarManager();
   }
@@ -108,15 +108,15 @@ const SomeComponent = () => {
   </TabItem>  
   <TabItem value="classComponent" label="Class component injection">
 
-To inject a class, annotate it with the `@Injectable` decorator. The `@Injectable` decorator takes a single parameter - the graph that should be used to resolve the dependencies. Declare the dependencies as class members and annotate them with the `@Inject` decorator.
+To inject a class, annotate it with the `@injectable` decorator. The `@injectable` decorator takes a single parameter - the graph that should be used to resolve the dependencies. Declare the dependencies as class members and annotate them with the `@Inject` decorator.
 
 ```ts title="MyComponent.tsx"
-import {Injectable, Inject} from 'react-obsidian';
+import {injectable, inject} from 'react-obsidian';
 import {ApplicationGraph} from './ApplicationGraph';
 
-@Injectable(ApplicationGraph)
+@injectable(ApplicationGraph)
 export MyClassComponent extends React.Component {
-  @Inject() private fooService!: FooService;
+  @inject() private fooService!: FooService;
 
 }
 ```
@@ -134,14 +134,14 @@ const SomeComponent = () => {
   </TabItem>
   <TabItem value="class" label="Class constructor injection">
 
-To inject a class, annotate it with the `@Injectable` decorator. The `@Injectable` decorator takes a single parameter - the graph that should be used to resolve the dependencies.
-Declare the dependencies as constructor parameters and annotate them with the `@Inject` decorator.
+To inject a class, annotate it with the `@injectable` decorator. The `@injectable` decorator takes a single parameter - the graph that should be used to resolve the dependencies.
+Declare the dependencies as constructor parameters and annotate them with the `@inject` decorator.
 
 ```ts title="MyClass.tsx"
-import {Injectable, Inject} from 'react-obsidian';
+import {injectable, inject} from 'react-obsidian';
 import {ApplicationGraph} from './ApplicationGraph';
 
-@Injectable(ApplicationGraph)
+@injectable(ApplicationGraph)
 export MyClass {
   constructor (fooService?: FooService);
   constructor(@Inject() private fooService: FooService) { }
@@ -186,5 +186,3 @@ React Obsidian is guided by the principles of the Dependency Injection pattern, 
 * **Easy to start** - Obsidian requires very little code to get you started. Once you declare a graph, using it to inject dependencies requires as little as two lines of code.
 * **Intuitive API** - The API should be verbose and understandable even to new users without prior experience with Dependency Injection.
 * **Minimal boilerplate** - Require the bare minimum in order to construct dependencies and resolve them. 
-
-<!-- ## Comparison with other libraries -->

--- a/packages/documentation/docs/documentation/installation.mdx
+++ b/packages/documentation/docs/documentation/installation.mdx
@@ -40,7 +40,7 @@ You'll need to add either the Babel or SWC plugins depending on your project's c
 <Tabs>
   <TabItem value="babel" label="Babel (React Native or Vite + Babel)" default>
 
-### Install the required Babel plugins
+#### Install the required Babel plugins
 
 You will need to install the `plugin-proposal-decorators` plugin if it's not installed already:
 <Tabs>
@@ -76,7 +76,7 @@ If this is your first time using Babel, you will also need to install Babel's co
   </TabItem>
 </Tabs>
 
-### Update your Babel configuration
+#### Update your Babel configuration
 
 Add the transformer and the required plugin to the list of plugins in your `babel.config.js` file or `.babelrc` file:
 
@@ -98,7 +98,7 @@ module.exports = {
   </TabItem>
   <TabItem value="swc" label="SWC (Vite + SWC)">
 
-### Install the required dependencies
+#### Install the required dependencies
 Currently, Obsidian can be used via [unplugin-swc](https://github.com/unplugin/unplugin-swc). [vite-plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc/) is not yet supported.
 
 <Tabs>
@@ -116,7 +116,7 @@ Currently, Obsidian can be used via [unplugin-swc](https://github.com/unplugin/u
   </TabItem>
 </Tabs>
 
-### Update your Vite configuration
+#### Update your Vite configuration
 Add the transformer to the list of plugins in your `vite.config.js` file:
 
 ```js title="vite.config.js"

--- a/packages/documentation/docs/documentation/meta/eslint.mdx
+++ b/packages/documentation/docs/documentation/meta/eslint.mdx
@@ -29,9 +29,9 @@ Ensure dependencies requested by providers can be resolved.
 When a provider requests a dependency that is not provided by the graph or its subgraphs, this rule will trigger a lint error.
 
 ```ts
-@Graph()
+@graph()
 class SomeGraph extends ObjectGraph {
-  @Provides()
+  @provides()
   someService(someDependency: SomeDependency) {
     //        ^ Since SomeDependency is not provided by the graph, this will trigger a lint error.
     return new SomeService(someDependency);
@@ -45,14 +45,14 @@ Prevent circular dependencies between providers.
 When two providers depend on each other, this rule will trigger a lint error.
 
 ```ts
-@Graph()
+@graph()
 class SomeGraph extends ObjectGraph {
-  @Provides()
+  @provides()
   foo(bar: Bar) {
     return new Foo(bar);
   }
 
-  @Provides()
+  @provides()
   bar(foo: Foo) {
     // ^ Since Foo depends on Bar, this will trigger a lint error.
     return new Bar(foo);

--- a/packages/documentation/docs/documentation/usage/ClassComponents.mdx
+++ b/packages/documentation/docs/documentation/usage/ClassComponents.mdx
@@ -4,15 +4,15 @@ title: "Class components"
 ---
 
 ## Injecting class components
-Injecting class components is a two step process. First, annotate the class with the `@Injectable` annotation and pass the graph from which dependencies should be resolve. Then, declare the dependencies as class members and annotate them with the `@Inject` annotation.
+Injecting class components is a two step process. First, annotate the class with the `@injectable` annotation and pass the graph from which dependencies should be resolve. Then, declare the dependencies as class members and annotate them with the `@inject` annotation.
 
 ```ts
-import {Injectable, Inject} from 'react-obsidian';
+import {injectable, inject} from 'react-obsidian';
 import {ApplicationGraph} from './ApplicationGraph';
 
-@Injectable(ApplicationGraph)
+@injectable(ApplicationGraph)
 export class ClassComponent extends React.Component {
-  @Inject() private httpClient!: HttpClient;
+  @inject() private httpClient!: HttpClient;
   
 }
 ```

--- a/packages/documentation/docs/documentation/usage/Classes.mdx
+++ b/packages/documentation/docs/documentation/usage/Classes.mdx
@@ -4,15 +4,15 @@ title: "Classes"
 ---
 
 ## Injecting classes
-Injecting classes is a two step process. First, annotate the class with the `@Injectable` annotation and pass the graph from which dependencies should be resolve. Then, declare the dependencies as class members and annotate them with the `@Inject` annotation.
+Injecting classes is a two step process. First, annotate the class with the `@injectable` annotation and pass the graph from which dependencies should be resolve. Then, declare the dependencies as class members and annotate them with the `@inject` annotation.
 
 ```ts
-import {Injectable, Inject} from 'react-obsidian';
+import {injectable, inject} from 'react-obsidian';
 import {ApplicationGraph} from './ApplicationGraph';
 
-@Injectable(ApplicationGraph)
+@injectable(ApplicationGraph)
 export class MyClass {
-  @Inject() private httpClient!: HttpClient;
+  @inject() private httpClient!: HttpClient;
   
 }
 ```
@@ -22,15 +22,15 @@ Constructor injection is the preferred way to inject dependencies. It is more ex
 :::
 
 ## Delayed injection
-Dependencies annotated with the `@Inject` annotation are resolved immediately **after** the constructor is called. If you want to inject a class at a later point in time, you can use the `@LateInject` annotation instead, and inject the dependencies by manually with the `Obsidian.inject()` function.
+Dependencies annotated with the `@inject` annotation are resolved immediately **after** the constructor is called. If you want to inject a class at a later point in time, you can use the `@lateInject` annotation instead, and inject the dependencies by manually with the `Obsidian.inject()` function.
 
 ```ts
-import {Injectable, LateInject} from 'react-obsidian';
+import {injectable, lateInject} from 'react-obsidian';
 import {ApplicationGraph} from './ApplicationGraph';
 
-@Injectable(ApplicationGraph)
+@injectable(ApplicationGraph)
 export class MyClass {
-  @LateInject() private httpClient!: HttpClient;
+  @lateInject() private httpClient!: HttpClient;
 
   public init() {
     console.log(this.httpClient === undefined); // true

--- a/packages/documentation/docs/documentation/usage/Graphs.mdx
+++ b/packages/documentation/docs/documentation/usage/Graphs.mdx
@@ -16,25 +16,25 @@ Before you can inject dependencies into hooks, components and classes, the depen
 The snippet below shows a basic example of a Graph. It defines two dependencies, `httpClient` and `databaseService`. 
 
 ```ts title="ApplicationGraph.ts"
-import {Singleton, Graph, ObjectGraph, Provides} from 'react-obsidian';
+import {singleton, graph, ObjectGraph, provides} from 'react-obsidian';
 
-@Singleton() @Graph()
+@singleton() @graph()
 export class ApplicationGraph extends ObjectGraph {
-  @Provides()
+  @provides()
   httpClient(): HttpClient {
     return new HttpClient();
   }
 
-  @Provides()
+  @provides()
   databaseService(): DatabaseService {
     return new DatabaseService();
   }
 }
 ```
 
-Graphs must be annotated with the `@Graph` decorator. In this example we chose to annotate the class with the `@Singleton` decorator as well, which means that the graph and the dependencies it provides will only be constructed once.
+Graphs must be annotated with the `@graph` decorator. In this example we chose to annotate the class with the `@singleton` decorator as well, which means that the graph and the dependencies it provides will only be constructed once.
 
-Dependencies are constructed in methods annotated with the `@Provides` annotation. The `@Provides` annotation is used to tell Obsidian that the method is a dependency provider. From now on we'll refer to these methods as providers. Obsidian uses the provider's method name as the dependency's name. In this example, the `httpClient` provider method provides the `httpClient` dependency. The `databaseService` provider method provides the `databaseService` dependency.
+Dependencies are constructed in methods annotated with the `@provides` annotation. The `@provides` annotation is used to tell Obsidian that the method is a dependency provider. From now on we'll refer to these methods as providers. Obsidian uses the provider's method name as the dependency's name. In this example, the `httpClient` provider method provides the `httpClient` dependency. The `databaseService` provider method provides the `databaseService` dependency.
 
 Once your graph is declared you can use it to inject dependencies into the various constructs that form your application:
 * [Inject hooks](/docs/documentation/usage/Hooks#injecting-hooks)
@@ -50,21 +50,21 @@ The term "graph" comes from [graph theory](https://en.wikipedia.org/wiki/Graph_t
 Some of the services defined in your graphs may be independent, meaning they don't require any dependencies to be constructed. However, most of the time, services will require other services to perform their responsibilities. In these cases, you can specify the dependencies of a service as arguments in the provider and Obsidian will resolve them automatically.
 
 ```ts title="A graph that provides a service that depends on other services"
-import {Singleton, Graph, ObjectGraph, Provides} from 'react-obsidian';
+import {singleton, graph, ObjectGraph, provides} from 'react-obsidian';
 
-@Singleton() @Graph()
+@singleton() @graph()
 export class ApplicationGraph extends ObjectGraph {
-  @Provides()
+  @provides()
   httpClient(): HttpClient {
     return new HttpClient();
   }
 
-  @Provides()
+  @provides()
   databaseService(): DatabaseService {
     return new DatabaseService();
   }
 
-  @Provides()
+  @provides()
   appInitializer(httpClient: HttpClient, databaseService: DatabaseService): AppInitializer {
     return new AppInitializer(httpClient, databaseService);
   }
@@ -82,7 +82,7 @@ There are two types of graphs in Obsidian: A singleton graph and a lifecycle-bou
 ### The singleton graph
 Applications typically have at least one singleton graph. These graphs are used to provide dependencies that are used throughout the application. These dependencies are usually singletons, which means they should only be constructed once. The `ApplicationGraph` in the [example above](/docs/documentation/usage/Graphs#specifying-relationships-between-dependencies) is a singleton graph.
 
-To declare a singleton graph, annotate the graph class with the `@Singleton` decorator.
+To declare a singleton graph, annotate the graph class with the `@singleton` decorator.
 
 ### The lifecycle-bound graph
 Lifecycle-bound graphs are used to provide dependencies that are shared between components and hooks in a specific UI scope.
@@ -90,11 +90,11 @@ Lifecycle-bound graphs are used to provide dependencies that are shared between 
 Obsidian supports injecting two types of UI scopes:
 1. **Feature scope (default)**: A feature scope is a scope that is shared between multiple screens. For example, a user authentication flow might consist of multiple screens that share the same dependencies. In this case, you can use a lifecycle-bound graph to provide the dependencies for the entire flow. When declaring a feature-scoped graph, a single instance of the graph is created and shared between all the components and hooks that request it.
 ```ts title="A feature-scoped lifecycle-bound graph"
-import {LifecycleBound, Graph, ObjectGraph, Provides} from 'react-obsidian';
+import {lifecycleBound, graph, ObjectGraph, provides} from 'react-obsidian';
 
-@LifecycleBound({scope: 'feature'}) @Graph()
+@lifecycleBound({scope: 'feature'}) @graph()
 class AuthGraph extends ObjectGraph {
-  @Provides()
+  @provides()
   userService(): UserService {
     return new UserService();
   }
@@ -102,11 +102,11 @@ class AuthGraph extends ObjectGraph {
 ```
 2. **Component scope**: A component scope is a scope that is shared between a component and its children. For example, a form component might have multiple input fields that share the same dependencies. In this case, you can use a component-scoped lifecycle-bound graph to provide the dependencies for the form.
 ```ts title="A component-scoped lifecycle-bound graph"
-import {LifecycleBound, Graph, ObjectGraph, Provides} from 'react-obsidian';
+import {lifecycleBound, graph, ObjectGraph, provides} from 'react-obsidian';
 
-@LifecycleBound({scope: 'component'}) @Graph()
+@lifecycleBound({scope: 'component'}) @graph()
 class FormGraph extends ObjectGraph {
-  @Provides()
+  @provides()
   validationService(): ValidationService {
     return new ValidationService();
   }
@@ -117,12 +117,12 @@ class FormGraph extends ObjectGraph {
 Lifecycle-bound graphs are feature-scoped by default.
 :::
 
-3. **Custom scope**: A custom scope is a special case of a feature scope. When multiple `@LifecycleBound` graphs share the same custom scope, they are considered to be part of the same UI scope. When a custom scoped graph is requested, Obsidian will create all the subgraphs in the same UI scope and destroy them when the last component or hook that requested them is unmounted.
+3. **Custom scope**: A custom scope is a special case of a feature scope. When multiple `@lifecycleBound` graphs share the same custom scope, they are considered to be part of the same UI scope. When a custom scoped graph is requested, Obsidian will create all the subgraphs in the same UI scope and destroy them when the last component or hook that requested them is unmounted.
 
 ```ts title="A custom-scoped lifecycle-bound graph"
-import {LifecycleBound, Graph, ObjectGraph, Provides} from 'react-obsidian';
+import {lifecycleBound, graph, ObjectGraph, provides} from 'react-obsidian';
 
-@LifecycleBound({scope: 'AppScope'}) @Graph({subgraphs: [ScreenGraph]})
+@lifecycleBound({scope: 'AppScope'}) @graph({subgraphs: [ScreenGraph]})
 class HomeScreenGraph extends ObjectGraph {
   constructor(private props: HomeScreenProps & BaseProps) {
     super(props);
@@ -131,7 +131,7 @@ class HomeScreenGraph extends ObjectGraph {
 ```
 
 ```ts title="A custom-scoped lifecycle-bound subgraph"
-@LifecycleBound({scope: 'AppScope'}) @Graph()
+@lifecycleBound({scope: 'AppScope'}) @graph()
 class ScreenGraph extends ObjectGraph {
   constructor(private props: BaseProps) {
     super(props);
@@ -147,16 +147,16 @@ The differences between a feature-scoped graph and a custom-scoped graph:
 :::
 
 #### Passing props to a lifecycle-bound graph
-When a graph is created, it receives the props of the component or hook that requested it. This means that the graph can use the props to construct the dependencies it provides. The `@LifecycleBound` in the example below graph provides a `userService` which requires a `userId`. The `userId` is obtained from props.
+When a graph is created, it receives the props of the component or hook that requested it. This means that the graph can use the props to construct the dependencies it provides. The `@lifecycleBound` in the example below graph provides a `userService` which requires a `userId`. The `userId` is obtained from props.
 
 ```ts title="A lifecycle-bound graph"
-import {LifecycleBound, Graph, ObjectGraph, Provides} from 'react-obsidian';
+import {lifecycleBound, graph, ObjectGraph, provides} from 'react-obsidian';
 
 type HomeScreenProps {
   userId: string;
 }
 
-@LifecycleBound() @Graph()
+@lifecycleBound() @graph()
 class HomeGraph extends ObjectGraph<HomeScreenProps> {
   private userId: string;
 
@@ -165,7 +165,7 @@ class HomeGraph extends ObjectGraph<HomeScreenProps> {
     this.userId = props.userId;
   }
 
-  @Provides()
+  @provides()
   userService(): UserService {
     return new UserService(this.userId);
   }
@@ -179,18 +179,18 @@ Lifecycle-bound graphs are created when they are requested and are destroyed whe
 Graph composition is a powerful feature that allows you to create complex dependency graphs by combining smaller graphs. Composing graphs is useful when you want to reuse a graph in multiple places. For example, you might have a singleton graph that provides application-level dependencies. You might also have a lifecycle-bound graph that provides dependencies for a specific UI flow. You can compose these graphs together so that the lifecycle-bound graph can also inject the dependencies provided by the singleton graph.
 
 ### Subgraphs
-The most common method to compose graphs is to pass a `subgraphs` array to the `@Graph` decorator. The `subgraphs` array contains the graphs you want to "include" in your graph.
+The most common method to compose graphs is to pass a `subgraphs` array to the `@graph` decorator. The `subgraphs` array contains the graphs you want to "include" in your graph.
 
 In the example below we declared a lifecycle-bound graph called `LoginGraph`. This graph provides a single dependency called `loginService` which has a dependency on `httpClient`. Since `httpClient` is exposed via the `ApplicationGraph`, we included it in the `subgraphs` array of our graph.
 
 
 ```ts title="LoginGraph.ts"
-import {Graph, ObjectGraph, Provides} from 'react-obsidian';
+import {graph, ObjectGraph, provides} from 'react-obsidian';
 import {ApplicationGraph} from './ApplicationGraph';
 
-@LifecycleBound() @Graph({subgraphs: [ApplicationGraph]}) 
+@lifecycleBound() @graph({subgraphs: [ApplicationGraph]}) 
 export class LoginGraph extends ObjectGraph {
-  @Provides()
+  @provides()
   loginService(httpClient: HttpClient): LoginService {
     return new LoginService(httpClient);
   }
@@ -205,10 +205,10 @@ In the example below we declared an abstract graph called `ScreenGraph`. This gr
 The `screenName` provider method is marked as `abstract` which means that it must be implemented by the parent class. This allows us to create multiple graphs that extend the `ScreenGraph` and provide the screen name.
 
 ```ts title="AbstractGraph.ts"
-import {Graph, ObjectGraph, Provides} from 'react-obsidian';
+import {graph, ObjectGraph, provides} from 'react-obsidian';
 
 export abstract class ScreenGraph extends ObjectGraph {
-  @Provides()
+  @provides()
   screenLogger(screenName: string) {
     return new ScreenLogger(screenName);
   }
@@ -224,16 +224,16 @@ The following two graphs extend the base `ScreenGraph`. Each graph provides a di
   <TabItem value="HomeGraph" label="HomeGraph">
 
 ```ts title="HomeGraph.ts"
-import {Graph, ObjectGraph, Provides} from 'react-obsidian';
+import {graph, ObjectGraph, provides} from 'react-obsidian';
 
-@Graph()
+@graph()
 export class HomeGraph extends ScreenGraph {
-  @Provides()
+  @provides()
   override screenName() {
     return 'HomeScreen';
   }
 
-  @Provides()
+  @provides()
   homeService(screenLogger: ScreenLogger): HomeService {
     return new HomeService(screenLogger);
   }
@@ -243,16 +243,16 @@ export class HomeGraph extends ScreenGraph {
   <TabItem value="ProfileGraph" label="ProfileGraph">
 
 ```ts title="ProfileGraph.ts"
-import {Graph, ObjectGraph, Provides} from 'react-obsidian';
+import {graph, ObjectGraph, provides} from 'react-obsidian';
 
-@Graph()
+@graph()
 export class ProfileGraph extends ScreenGraph {
-  @Provides()
+  @provides()
   override screenName() {
     return 'ProfileScreen';
   }
 
-  @Provides()
+  @provides()
   profileService(screenLogger: ScreenLogger): ProfileService {
     return new ProfileService(screenLogger);
   }
@@ -262,7 +262,7 @@ export class ProfileGraph extends ScreenGraph {
 </Tabs>
 
 :::note
-Because abstract graphs aren't instantiated directly, they don't need to be annotated with the `@Graph` decorator. Abstract providers aren't annotated with the `@Provides` decorator for the same reason.
+Because abstract graphs aren't instantiated directly, they don't need to be annotated with the `@graph` decorator. Abstract providers aren't annotated with the `@provides` decorator for the same reason.
 :::
 
 ## Typed dependencies

--- a/packages/documentation/docs/documentation/usage/ServiceLocator.mdx
+++ b/packages/documentation/docs/documentation/usage/ServiceLocator.mdx
@@ -14,16 +14,16 @@ For these cases, you can obtain a graph instance and access the dependencies it 
 Consider the following graph which provides two dependencies: `fooService` and `barService` where `barService` depends on `fooService`:
 
 ```ts
-import {Singleton, Graph, ObjectGraph, Provides} from 'react-obsidian';
+import {singleton, graph, ObjectGraph, provides} from 'react-obsidian';
 
-@Singleton() @Graph()
+@singleton() @graph()
 export class SomeGraph extends ObjectGraph {
-  @Provides()
+  @provides()
   fooService(): FooService {
     return new FooService();
   }
 
-  @Provides()
+  @provides()
   barService(fooService: FooService): AppInitializer {
     return new BarService(fooService);
   }

--- a/packages/documentation/docs/guides/avoidingPropDrilling.mdx
+++ b/packages/documentation/docs/guides/avoidingPropDrilling.mdx
@@ -4,7 +4,7 @@ title: ' Avoiding prop drilling'
 tags: [Architecture, Reactivity, Lifecycle-bound, Graph]
 ---
 
-Prop Drilling is a common issue in React development where props are passed down multiple levels of the component hierarchy, making the code difficult to maintain and understand. This guide will show you how to use `@LifecycleBound` graphs to avoid Prop Drilling.
+Prop Drilling is a common issue in React development where props are passed down multiple levels of the component hierarchy, making the code difficult to maintain and understand. This guide will show you how to use `@lifecycleBound` graphs to avoid Prop Drilling.
 
 ## Understanding lifecycle-bound graphs
 
@@ -45,8 +45,8 @@ const ComponentC = ({ userId }) => {
 
 In this example, the `userId` prop is drilled down from `ComponentA` to `ComponentC` through `ComponentB`. This approach can become cumbersome as the number of components and the depth of the hierarchy increase.
 
-## Avoiding prop drilling with `@LifecycleBound` graphs
-Let's refactor this code to use a `@LifecycleBound` graph to avoid prop drilling.
+## Avoiding prop drilling with `@lifecycleBound` graphs
+Let's refactor this code to use a `@lifecycleBound` graph to avoid prop drilling.
 
 #### Step 1: Define a lifecycle-bound graph
 
@@ -57,10 +57,10 @@ Notice how the graph receives `ComponentA`'s props in its constructor and provid
 :::
 
 ```tsx title="UserGraph.ts"
-import { LifecycleBound, Graph, ObjectGraph, Provides } from 'react-obsidian';
+import { lifecycleBound, graph, ObjectGraph, provides } from 'react-obsidian';
 import {Props} from './ComponentA';
 
-@LifecycleBound() @Graph()
+@lifecycleBound() @graph()
 export class UserGraph extends ObjectGraph<UserProps> {
   private userId: string;
 
@@ -69,7 +69,7 @@ export class UserGraph extends ObjectGraph<UserProps> {
     this.userId = props.userId;
   }
 
-  @Provides()
+  @provides()
   userId(): string {
     return this.userId;
   }
@@ -139,5 +139,5 @@ const App = () => {
 export default App;
 ```
 
-## Conclusion
-By using `@LifecycleBound` graphs, we've eliminated the need for prop drilling. Dependencies like `userId` are automatically injected where needed, making the code cleaner and easier to maintain.
+## Wrapping up
+By using `@lifecycleBound` graphs, we've eliminated the need for prop drilling. Dependencies like `userId` are automatically injected where needed, making the code cleaner and easier to maintain.

--- a/packages/documentation/docs/guides/configurableApplications.mdx
+++ b/packages/documentation/docs/guides/configurableApplications.mdx
@@ -34,9 +34,9 @@ In this example we'll learn how to change the concrete object returned by a prov
 Lets declare a simple graph that provides a single dependency: an HTTP client used to make network requests.
 
 ```ts
-@Singleton() @Graph()
+@singleton() @graph()
 class ApplicationGraph extends ObjectGraph {
-  @Provides()
+  @provides()
   httpClient(): HttpClient {
     return new HttpClient();
   }
@@ -127,14 +127,14 @@ class AxiosClient implements NetworkClient {
 To determine which client to return, we'll use a new dependency called `AppConfig` which will be used to access the application's configuration.
 
 ```ts
-@Singleton() @Graph()
+@singleton() @graph()
 class ApplicationGraph extends ObjectGraph {
-  @Provides()
+  @provides()
   httpClient(appConfig: AppConfig): NetworkClient {
     return appConfig.shouldUseAxiosClient() ? new AxiosClient() : new HttpClient();
   }
 
-  @Provides()
+  @provides()
   appConfig(): AppConfig {
     return new AppConfig();
   }
@@ -159,9 +159,9 @@ In this example we'll learn how to mock a dependency and how to use that mocked 
 As in the previous example, we'll declare a simple graph that provides a single dependency: an HTTP client used to make network requests.
 
 ```ts
-@Singleton() @Graph()
+@singleton() @graph()
 export class ApplicationGraph extends ObjectGraph {
-  @Provides()
+  @provides()
   httpClient(): HttpClient {
     return new HttpClient();
   }
@@ -174,9 +174,9 @@ To provide a mocked HTTP client to all objects involved in the test, we'll creat
 ```ts
 import { mock } from 'jest-mock-extended';
 
-@Singleton() @Graph()
+@singleton() @graph()
 export class ApplicationGraphForTests extends ApplicationGraph {
-  @Provides()
+  @provides()
   override httpClient(): HttpClient {
     return mock<HttpClient>();
   }

--- a/packages/documentation/docs/guides/mvvm.mdx
+++ b/packages/documentation/docs/guides/mvvm.mdx
@@ -92,17 +92,17 @@ export const Counter = injectComponent(_Counter, CounterGraph);
 At this point we have our Model, View, and View Model written. However, we still need to connect them to one another. We can do this by creating a graph.
 
 ```ts title="CounterGraph.ts"
-import { Graph, ObjectGraph, Provides } from "react-obsidian";
+import { graph, ObjectGraph, provides } from "react-obsidian";
 
-@Singleton() @Graph()
+@singleton() @graph()
 export class CounterGraph {
-  @Provides()
+  @provides()
   model(): CounterModel {
     return new CounterModel();
   }
 
  // The useViewModel hook is instantiated once and injected into the Counter component
-  @Provides()
+  @provides()
   useViewModel(model: CounterModel) {
     return () => useCounterViewModel(model);
   }

--- a/packages/documentation/docs/reference/testKit/mockGraphs.mdx
+++ b/packages/documentation/docs/reference/testKit/mockGraphs.mdx
@@ -21,9 +21,9 @@ Replaces the implementation of the given graphs with mock implementations.
 ### Mocking a graph
 Lets say we have a graph that looks like this:
 ```ts
-@Singleton() @Graph()
+@singleton() @graph()
 class AppGraph {
-  @Provides()
+  @provides()
   storage(): Storage {
     return new Storage();
   }
@@ -49,9 +49,9 @@ class FakeStorage extends Storage {
 Next, we'll create a graph that provides a fake implementation of Storage.
 
 ```ts
-@Singleton() @Graph()
+@singleton() @graph()
 class AppGraphForIntegrationTests {
-  @Provides()
+  @provides()
   override storage(): Storage {
     return new FakeStorage();
   }

--- a/packages/eslint-plugin-obsidian/package.json
+++ b/packages/eslint-plugin-obsidian/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-obsidian",
   "description": "ESLint rules for Obsidian",
   "main": "dist/index.js",
-  "version": "2.16.0",
+  "version": "2.17.0+alpha.1",
   "scripts": {
     "build": "npx tsc --project tsconfig.prod.json",
     "test": "npx jest",

--- a/packages/eslint-plugin-obsidian/package.json
+++ b/packages/eslint-plugin-obsidian/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-obsidian",
   "description": "ESLint rules for Obsidian",
   "main": "dist/index.js",
-  "version": "2.17.0+alpha.1",
+  "version": "2.17.0-alpha.1",
   "scripts": {
     "build": "npx tsc --project tsconfig.prod.json",
     "test": "npx jest",

--- a/packages/eslint-plugin-obsidian/package.json
+++ b/packages/eslint-plugin-obsidian/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-obsidian",
   "description": "ESLint rules for Obsidian",
   "main": "dist/index.js",
-  "version": "2.17.0-alpha.1",
+  "version": "2.18.0-alpha.1",
   "scripts": {
     "build": "npx tsc --project tsconfig.prod.json",
     "test": "npx jest",

--- a/packages/eslint-plugin-obsidian/src/dto/class.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/class.ts
@@ -14,6 +14,10 @@ export class Clazz {
     return this.node.abstract;
   }
 
+  public isDecoratedWithIgnoreCase(decoratorName: string) {
+    return this.decoratorNames.some(name => name.toLowerCase() === decoratorName.toLowerCase());
+  }
+
   get decoratorNames() {
     return this.decorators.map((decorator: Decorator) => {
       return decorator.expression.callee.name;
@@ -42,12 +46,12 @@ export class Clazz {
     return this.body
       .filter(isMethodDefinition)
       .map((node) => new Method(node))
-      .filter((method) => method.isDecoratedWith(decoratorName));
+      .filter(method => method.isDecoratedWithIgnoreCase(decoratorName));
   }
 
-  public requireDecorator(name: string) {
+  public requireDecoratorIgnoreCase(name: string) {
     const decorator = this.decorators.find(($decorator: Decorator) => {
-      return $decorator.expression.callee.name === name;
+      return $decorator.expression.callee.name.toLowerCase() === name.toLowerCase();
     });
     assertDefined(decorator, `Decorator ${name} not found on class ${this.name}`);
     return decorator;

--- a/packages/eslint-plugin-obsidian/src/dto/componentProps.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/componentProps.ts
@@ -1,9 +1,9 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import {
-isAnyType,
-isTypeAnnotation,
-isTypeIntersection,
-isTypeReference,
+  isAnyType,
+  isTypeAnnotation,
+  isTypeIntersection,
+  isTypeReference,
 } from '../utils/ast';
 import { SingleType } from './types/singleType';
 import { TypeIntersection } from './types/typeIntersection';

--- a/packages/eslint-plugin-obsidian/src/dto/file.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/file.ts
@@ -1,10 +1,10 @@
 import type { TSESTree } from '@typescript-eslint/types';
 import { Clazz } from './class';
 import {
-getClassDeclaration,
-isClassLike,
-isImportDeclaration,
-isVariableDeclaration,
+  getClassDeclaration,
+  isClassLike,
+  isImportDeclaration,
+  isVariableDeclaration,
 } from '../utils/ast';
 import { Import } from './import';
 import { ClassFile } from './classFile';
@@ -13,7 +13,7 @@ import { Variable } from './variable';
 
 export class File {
   constructor(program: TSESTree.Program, path?: string);
-  constructor(private program: TSESTree.Program,private path: string) { }
+  constructor(private program: TSESTree.Program, private path: string) { }
 
   public requireGraph(name: string) {
     const graph = this.classNodes.find((node) => {
@@ -53,7 +53,7 @@ export class File {
         return clazz && new Clazz(clazz);
       })
       .filter((clazz: Clazz | undefined) => {
-        return clazz ? clazz.decoratorNames.includes('Graph') : false;
+        return clazz ? clazz.isDecoratedWithIgnoreCase('Graph') : false;
       }) as Clazz[];
   }
 

--- a/packages/eslint-plugin-obsidian/src/dto/method.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/method.ts
@@ -14,9 +14,9 @@ export class Method {
     return this.node.value.params.map((param) => new Parameter(param));
   }
 
-  isDecoratedWith(decoratorName: string): boolean {
+  isDecoratedWithIgnoreCase(decoratorName: string): boolean {
     return this.decorators.some((decorator) => {
-      return decorator.expression.callee.name === decoratorName;
+      return decorator.expression.callee.name.toLowerCase() === decoratorName.toLowerCase();
     });
   }
 

--- a/packages/eslint-plugin-obsidian/src/dto/variable.ts
+++ b/packages/eslint-plugin-obsidian/src/dto/variable.ts
@@ -1,4 +1,4 @@
-import type { TSESTree } from '@typescript-eslint/types';
+import { TSESTree } from '@typescript-eslint/types';
 import assert from 'assert';
 
 export class Variable {
@@ -9,7 +9,7 @@ export class Variable {
   }
 
   get isArrowFunction(): boolean {
-    return this.node.init?.type === 'ArrowFunctionExpression';
+    return this.node.init?.type === TSESTree.AST_NODE_TYPES.ArrowFunctionExpression;
   }
 
   get arrowFunction(): TSESTree.ArrowFunctionExpression {

--- a/packages/eslint-plugin-obsidian/src/rules/noCircularDependency/graphHandler.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/noCircularDependency/graphHandler.ts
@@ -16,6 +16,6 @@ export class GraphHandler {
   }
 
   private hasGraphDecorator(clazz: Clazz) {
-    return clazz.decoratorNames.includes('Graph');
+    return clazz.isDecoratedWithIgnoreCase('Graph');
   }
 }

--- a/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/graphHandler.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/graphHandler.ts
@@ -21,6 +21,6 @@ export class GraphHandler {
   }
 
   private hasGraphDecorator(clazz: Clazz) {
-    return clazz.decoratorNames.includes('Graph');
+    return clazz.isDecoratedWithIgnoreCase('Graph');
   }
 }

--- a/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/subgraphResolver.ts
+++ b/packages/eslint-plugin-obsidian/src/rules/unresolvedProviderDependencies/subgraphResolver.ts
@@ -51,7 +51,7 @@ export class SubgraphResolver {
 
   private getSubgraphsPropertyFromGraphDecorator({clazz}: ClassFile) {
     if (clazz.isAbstract) return undefined;
-    const graphDecorator = clazz.requireDecorator('Graph');
+    const graphDecorator = clazz.requireDecoratorIgnoreCase('Graph');
     return graphDecorator.getProperty('subgraphs');
   }
 

--- a/packages/eslint-plugin-obsidian/src/utils/ast.ts
+++ b/packages/eslint-plugin-obsidian/src/utils/ast.ts
@@ -1,14 +1,14 @@
-import type { TSESTree } from '@typescript-eslint/types';
+import { AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/types';
 import type { ArrayExpressionElement } from '../types';
 import { assertDefined } from './assertions';
 
 export function isClassLike(node: TSESTree.Node): node is TSESTree.ClassDeclaration {
   switch (node.type) {
-    case 'ClassDeclaration':
+    case AST_NODE_TYPES.ClassDeclaration:
       return true;
-    case 'ExportDefaultDeclaration':
+    case AST_NODE_TYPES.ExportDefaultDeclaration:
       return isClassLike(node.declaration);
-    case 'ExportNamedDeclaration':
+    case AST_NODE_TYPES.ExportNamedDeclaration:
       return isClassLike(node.declaration!);
     default:
       return false;
@@ -16,28 +16,28 @@ export function isClassLike(node: TSESTree.Node): node is TSESTree.ClassDeclarat
 }
 
 export function isTypeReference(node?: TSESTree.Node): node is TSESTree.TSTypeReference {
-  return node?.type === 'TSTypeReference';
+  return node?.type === AST_NODE_TYPES.TSTypeReference;
 }
 
 export function isTypeLiteral(node: TSESTree.Node): node is TSESTree.TSTypeLiteral {
-  return node.type === 'TSTypeLiteral';
+  return node.type === AST_NODE_TYPES.TSTypeLiteral;
 }
 
 export function isImportDeclaration(node: TSESTree.Node): node is TSESTree.ImportDeclaration {
-  return node.type === 'ImportDeclaration';
+  return node.type === AST_NODE_TYPES.ImportDeclaration;
 }
 
 export function isMethodDefinition(node: TSESTree.Node): node is TSESTree.MethodDefinition {
-  return node.type === 'MethodDefinition';
+  return node.type === AST_NODE_TYPES.MethodDefinition;
 }
 
 export function getClassDeclaration(node: TSESTree.Node): TSESTree.ClassDeclaration | undefined {
   switch (node.type) {
-    case 'ClassDeclaration':
+    case AST_NODE_TYPES.ClassDeclaration:
       return node;
-    case 'ExportDefaultDeclaration':
+    case AST_NODE_TYPES.ExportDefaultDeclaration:
       return getClassDeclaration(node.declaration);
-    case 'ExportNamedDeclaration':
+    case AST_NODE_TYPES.ExportNamedDeclaration:
       return getClassDeclaration(node.declaration!);
     default:
       return undefined;
@@ -47,7 +47,7 @@ export function getClassDeclaration(node: TSESTree.Node): TSESTree.ClassDeclarat
 export function requireProgram(node: TSESTree.Node | undefined): TSESTree.Program {
   assertDefined(node);
   switch (node.type) {
-    case 'Program':
+    case AST_NODE_TYPES.Program:
       return node;
     default:
       return requireProgram(node.parent);
@@ -64,8 +64,8 @@ export function getDecoratorProperty(decorator: TSESTree.Decorator, propertyName
 
 function getObjectProperty(obj: TSESTree.ObjectExpression, propertyName: string) {
   return obj.properties.find((property) => {
-    return property.type === 'Property'
-      && property.key.type === 'Identifier'
+    return property.type === AST_NODE_TYPES.Property
+      && property.key.type === AST_NODE_TYPES.Identifier
       && property.key.name === propertyName;
   }) as TSESTree.Property | undefined;
 }
@@ -75,17 +75,17 @@ export function mapArrayExpression<T>(array: TSESTree.ArrayExpression, map: (el:
 }
 
 export function isTypeIntersection(node: TSESTree.Node | undefined): node is TSESTree.TSIntersectionType {
-  return node?.type === 'TSIntersectionType';
+  return node?.type === AST_NODE_TYPES.TSIntersectionType;
 }
 
 export function isTypeAnnotation(node: TSESTree.Node | undefined): node is TSESTree.TSTypeAnnotation {
-  return node?.type === 'TSTypeAnnotation';
+  return node?.type === AST_NODE_TYPES.TSTypeAnnotation;
 }
 
 export function isAnyType(node: TSESTree.Node | undefined): node is TSESTree.TSAnyKeyword {
-  return node?.type === 'TSAnyKeyword';
+  return node?.type === AST_NODE_TYPES.TSAnyKeyword;
 }
 
 export function isVariableDeclaration(node: TSESTree.Node): node is TSESTree.VariableDeclaration {
-  return node.type === 'VariableDeclaration';
+  return node.type === AST_NODE_TYPES.VariableDeclaration;
 }

--- a/packages/react-obsidian/package.json
+++ b/packages/react-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-obsidian",
-  "version": "2.17.0+alpha.1",
+  "version": "2.17.0-alpha.1",
   "description": "Dependency injection framework for React and React Native applications",
   "scripts": {
     "prepack": "npm run lint && tsc --project tsconfig.prod.json",

--- a/packages/react-obsidian/package.json
+++ b/packages/react-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-obsidian",
-  "version": "2.16.0",
+  "version": "2.17.0+alpha.1",
   "description": "Dependency injection framework for React and React Native applications",
   "scripts": {
     "prepack": "npm run lint && tsc --project tsconfig.prod.json",

--- a/packages/react-obsidian/package.json
+++ b/packages/react-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-obsidian",
-  "version": "2.17.0-alpha.1",
+  "version": "2.18.0-alpha.1",
   "description": "Dependency injection framework for React and React Native applications",
   "scripts": {
     "prepack": "npm run lint && tsc --project tsconfig.prod.json",

--- a/packages/react-obsidian/src/decorators/Graph.ts
+++ b/packages/react-obsidian/src/decorators/Graph.ts
@@ -6,7 +6,7 @@ interface GraphParams {
   subgraphs: Constructable<ObjectGraph>[];
 }
 
-export function Graph({ subgraphs = [] }: Partial<GraphParams> = {}) {
+export function graph({ subgraphs = [] }: Partial<GraphParams> = {}) {
   return (constructor: any) => {
     graphRegistry.register(constructor, subgraphs);
     return constructor;

--- a/packages/react-obsidian/src/decorators/LifecycleBound.ts
+++ b/packages/react-obsidian/src/decorators/LifecycleBound.ts
@@ -4,7 +4,7 @@ type Options = {
   scope?: 'component' | 'feature' | (string & {});
 };
 
-export function LifecycleBound(options?: Options) {
+export function lifecycleBound(options?: Options) {
   return (constructor: any) => {
     Reflect.defineMetadata('isLifecycleBound', true, constructor);
     Reflect.defineMetadata('lifecycleScope', options?.scope ?? 'feature', constructor);

--- a/packages/react-obsidian/src/decorators/Singleton.ts
+++ b/packages/react-obsidian/src/decorators/Singleton.ts
@@ -2,12 +2,12 @@ import { Constructable } from '../types';
 import { ObjectGraph } from '../graph/ObjectGraph';
 import {Reflect} from '../utils/reflect';
 
-export function Singleton() {
-  return function singleton(
+export function singleton() {
+  return (
     constructorOrGraph: Constructable<ObjectGraph> | ObjectGraph,
     _property?: string,
     descriptor?: PropertyDescriptor,
-  ): any {
+  ): any => {
     const target = descriptor || constructorOrGraph;
     Reflect.defineMetadata('isSingleton', true, target);
     return target;

--- a/packages/react-obsidian/src/decorators/inject/Inject.ts
+++ b/packages/react-obsidian/src/decorators/inject/Inject.ts
@@ -1,7 +1,7 @@
 import { isNumber } from '../../utils/isNumber';
 import InjectionMetadata from '../../injectors/class/InjectionMetadata';
 
-export function Inject(name?: string) {
+export function inject(name?: string) {
   return (
     target: Object | any,
     _propertyKey?: string,

--- a/packages/react-obsidian/src/decorators/inject/Injectable.ts
+++ b/packages/react-obsidian/src/decorators/inject/Injectable.ts
@@ -3,6 +3,6 @@ import { Graph } from '../../graph/Graph';
 import graphRegistry from '../../graph/registry/GraphRegistry';
 import ClassInjector from '../../injectors/class/ClassInjector';
 
-export function Injectable(keyOrGraph: string | Constructable<Graph>): any {
+export function injectable(keyOrGraph: string | Constructable<Graph>): any {
   return new ClassInjector(graphRegistry).inject(keyOrGraph);
 }

--- a/packages/react-obsidian/src/decorators/inject/LateInject.ts
+++ b/packages/react-obsidian/src/decorators/inject/LateInject.ts
@@ -1,6 +1,6 @@
 import InjectionMetadata from '../../injectors/class/InjectionMetadata';
 
-export function LateInject(name?: string): any {
+export function lateInject(name?: string): any {
   return (target: object) => {
     const metadata = new InjectionMetadata();
     metadata.saveLatePropertyMetadata(target.constructor, name!);

--- a/packages/react-obsidian/src/decorators/provides/Provides.ts
+++ b/packages/react-obsidian/src/decorators/provides/Provides.ts
@@ -6,8 +6,8 @@ interface ProvidesParams {
   name: string;
 }
 
-export function Provides({ name }: Partial<ProvidesParams> = {}) {
-  return function provide(graph: Graph, propertyKey: string, descriptor: PropertyDescriptor) {
+export function provides({ name }: Partial<ProvidesParams> = {}) {
+  return (graph: Graph, propertyKey: string, descriptor: PropertyDescriptor) => {
     providedPropertiesStore.set(graph, propertyKey, name!);
     return memoizeDescriptor(propertyKey, descriptor);
   };

--- a/packages/react-obsidian/src/index.ts
+++ b/packages/react-obsidian/src/index.ts
@@ -1,18 +1,55 @@
+import { graph } from './decorators/Graph';
+import { inject } from './decorators/inject/Inject';
+import { injectable } from './decorators/inject/Injectable';
+import { lateInject } from './decorators/inject/LateInject';
+import { lifecycleBound } from './decorators/LifecycleBound';
+import { provides } from './decorators/provides/Provides';
+import { singleton } from './decorators/Singleton';
 import _Obsidian from './Obsidian';
 
 export * from './types';
 
-export { Graph } from './decorators/Graph';
-export { Singleton } from './decorators/Singleton';
+export { graph } from './decorators/Graph';
+export { singleton } from './decorators/Singleton';
 export { ObjectGraph } from './graph/ObjectGraph';
 export { Graph as IGraph } from './graph/Graph';
-export { Provides } from './decorators/provides/Provides';
-export { Injectable } from './decorators/inject/Injectable';
-export { Inject } from './decorators/inject/Inject';
-export { LateInject } from './decorators/inject/LateInject';
-export { LifecycleBound } from './decorators/LifecycleBound';
+export { provides } from './decorators/provides/Provides';
+export { injectable } from './decorators/inject/Injectable';
+export { inject } from './decorators/inject/Inject';
+export { lateInject } from './decorators/inject/LateInject';
+export { lifecycleBound } from './decorators/LifecycleBound';
 export { GraphMiddleware } from './graph/registry/GraphMiddleware';
 export { GraphResolveChain as ResolveChain } from './graph/registry/GraphResolveChain';
+
+/**
+ * @deprecated Uppercase decorators are deprecated in favor of lowercase decorators to align with common naming conventions. Please use `@graph` instead.
+ */
+export const Graph = graph;
+/**
+ * @deprecated Uppercase decorators are deprecated in favor of lowercase decorators to align with common naming convention. Please use `@singleton` instead.
+ */
+export const Singleton = singleton;
+/**
+ * @deprecated Uppercase decorators are deprecated in favor of lowercase decorators to align with common naming convention. Please use `@provides` instead.
+ */
+export const Provides = provides;
+/**
+ * @deprecated Uppercase decorators are deprecated in favor of lowercase decorators to align with common naming convention. Please use `@injectable` instead.
+ */
+export const Injectable = injectable;
+/**
+ * @deprecated Uppercase decorators are deprecated in favor of lowercase decorators to align with common naming convention. Please use `@inject` instead.
+ */
+export const Inject = inject;
+/**
+ * @deprecated Uppercase decorators are deprecated in favor of lowercase decorators to align with common naming convention. Please use `@lateInject` instead.
+ */
+export const LateInject = lateInject;
+/**
+ * @deprecated Uppercase decorators are deprecated in favor of lowercase decorators to align with common naming convention. Please use `@lifecycleBound` instead.
+ */
+export const LifecycleBound = lifecycleBound;
+
 
 export const Obsidian = new _Obsidian();
 

--- a/packages/react-obsidian/test/fixtures/LifecycleBoundGraph.ts
+++ b/packages/react-obsidian/test/fixtures/LifecycleBoundGraph.ts
@@ -1,9 +1,13 @@
-import { Graph, ObjectGraph, Provides } from '../../src';
-import { LifecycleBound } from '../../src/decorators/LifecycleBound';
+import {
+  graph,
+  ObjectGraph,
+  provides,
+  lifecycleBound,
+} from '../../src';
 
 export type Props = Record<string, any> & { stringFromProps: string };
 
-@LifecycleBound() @Graph()
+@lifecycleBound() @graph()
 export class LifecycleBoundGraph extends ObjectGraph<Props> {
   static timesCreated = 0;
   private props: Props;
@@ -14,14 +18,14 @@ export class LifecycleBoundGraph extends ObjectGraph<Props> {
     LifecycleBoundGraph.timesCreated++;
   }
 
-  @Provides()
+  @provides()
   computedFromProps(): string {
     return this.props.stringFromProps
       ? `A string passed via props: ${this.props.stringFromProps}`
       : 'stringFromProps does not exist';
   }
 
-  @Provides()
+  @provides()
   doesNotRequireProps(): string {
     return 'A string that does not require props';
   }

--- a/packages/react-obsidian/test/fixtures/LifecycleBoundWithLifecycleBoundSubgraph.ts
+++ b/packages/react-obsidian/test/fixtures/LifecycleBoundWithLifecycleBoundSubgraph.ts
@@ -1,13 +1,17 @@
-import { Graph, ObjectGraph, Provides } from '../../src';
-import { LifecycleBound } from '../../src/decorators/LifecycleBound';
+import {
+  graph,
+  ObjectGraph,
+  provides,
+  lifecycleBound,
+} from '../../src';
 import { LifecycleBoundGraph } from './LifecycleBoundGraph';
 
 export type Props = Record<string, any> & { stringFromProps: string };
 
-@LifecycleBound() @Graph({subgraphs: [LifecycleBoundGraph]})
+@lifecycleBound() @graph({ subgraphs: [LifecycleBoundGraph] })
 export class LifecycleBoundGraphWithLifecycleBoundSubgraph extends ObjectGraph {
 
-  @Provides()
+  @provides()
   aString(computedFromProps: string): string {
     return `A string that requires props from a lifecycle bound subgraph: ${computedFromProps}`;
   }

--- a/packages/react-obsidian/test/fixtures/ScopedLifecycleBoundGraph.ts
+++ b/packages/react-obsidian/test/fixtures/ScopedLifecycleBoundGraph.ts
@@ -1,9 +1,8 @@
-import { Graph, ObjectGraph } from '../../src';
-import { LifecycleBound } from '../../src/decorators/LifecycleBound';
+import { graph, ObjectGraph, lifecycleBound } from '../../src';
 
 export type Props = Record<string, any> & { stringFromProps: string };
 
-@LifecycleBound({scope: 'component'}) @Graph()
+@lifecycleBound({scope: 'component'}) @graph()
 export class ScopedLifecycleBoundGraph extends ObjectGraph<Props> {
 
 }

--- a/packages/react-obsidian/test/fixtures/SingletonGraph.ts
+++ b/packages/react-obsidian/test/fixtures/SingletonGraph.ts
@@ -1,12 +1,12 @@
 import { uniqueId } from 'lodash';
-import { Singleton } from '../../src/decorators/Singleton';
-import { Graph, ObjectGraph, Provides } from '../../src';
+import { singleton } from '../../src/decorators/Singleton';
+import { graph, ObjectGraph, provides } from '../../src';
 
-@Singleton() @Graph()
+@singleton() @graph()
 export default class SingletonGraph extends ObjectGraph {
   private id = uniqueId();
 
-  @Provides()
+  @provides()
   instanceId(): string {
     return `graph${this.id}`;
   }

--- a/packages/react-obsidian/test/integration/mockingGraphs.test.tsx
+++ b/packages/react-obsidian/test/integration/mockingGraphs.test.tsx
@@ -4,10 +4,10 @@ import SingletonGraph from '../fixtures/SingletonGraph';
 import MainGraph from '../fixtures/MainGraph';
 import Subgraph from '../fixtures/Subgraph';
 import {
-  Graph,
+  graph,
   Obsidian,
-  Provides,
-  Singleton,
+  singleton,
+  provides,
 } from '../../src';
 import InjectedComponent from '../fixtures/InjectedComponent';
 import { mockGraphs } from '../../testkit';
@@ -35,37 +35,37 @@ describe('Test doubles', () => {
   });
 
   it('Mocks graphs when using Obsidian.obtain on a Singleton graph'
-  + 'even after the singleton graph was already registered in graph registry', () => {
-    registerSingletonGraphBeforeMocking();
+    + 'even after the singleton graph was already registered in graph registry', () => {
+      registerSingletonGraphBeforeMocking();
 
-    const stringToCompare = Obsidian.obtain(SingletonGraph).instanceId();
-    expect(stringToCompare).toBe('MockSingleton');
-  });
+      const stringToCompare = Obsidian.obtain(SingletonGraph).instanceId();
+      expect(stringToCompare).toBe('MockSingleton');
+    });
 
   function registerSingletonGraphBeforeMocking() {
     Obsidian.obtain(SingletonGraph);
     mockGraphs({ SingletonGraph: MockSingletonGraph });
   }
 
-  @Singleton() @Graph()
+  @singleton() @graph()
   class MockSingletonGraph extends SingletonGraph {
-    @Provides()
+    @provides()
     override instanceId(): string {
       return 'MockSingleton';
     }
   }
 
-  @Graph()
+  @graph()
   class MockMainGraph extends MainGraph {
-    @Provides()
+    @provides()
     override someString(): string {
       return 'Mocked';
     }
   }
 
-  @Graph()
+  @graph()
   class MockSubgraph extends Subgraph {
-    @Provides()
+    @provides()
     override stringFromSubgraph(): string {
       return 'Content';
     }

--- a/packages/react-obsidian/transformers/babel-plugin-obsidian/__snapshots__/index.test.ts.snap
+++ b/packages/react-obsidian/transformers/babel-plugin-obsidian/__snapshots__/index.test.ts.snap
@@ -1,6 +1,103 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Provider Arguments Transformer Adds method name to provider arguments (@Provider() -> @Provider({name: "myProvidedDependency"}) 1`] = `
+exports[`Provider Arguments Transformer Testing with deprecated syntax Adds method name to provider arguments (@Provider() -> @Provider({name: "myProvidedDependency"}) 1`] = `
+"var _dec, _class;
+function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
+let MainGraph = (_dec = provides({
+  name: "someString"
+}), _class = class MainGraph {
+  someString({
+    stringProvider: stringProvider,
+    emptyString: emptyString
+  }) {
+    return stringProvider.theString + emptyString;
+  }
+}, _applyDecoratedDescriptor(_class.prototype, "someString", [_dec], Object.getOwnPropertyDescriptor(_class.prototype, "someString"), _class.prototype), _class);"
+`;
+
+exports[`Provider Arguments Transformer Testing with deprecated syntax Adds property name to @Inject arguments @Inject -> @Inject("myDependency") 1`] = `
+"var _dec, _class, _descriptor;
+function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
+function _initializerWarningHelper(r, e) { throw Error("Decorating class property failed. Please ensure that transform-class-properties is enabled and runs after the decorators transform."); }
+let MainGraph = (_dec = inject("someString"), _class = class MainGraph {
+  someString = _initializerWarningHelper(_descriptor, this);
+}, _descriptor = _applyDecoratedDescriptor(_class.prototype, "someString", [_dec], {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  initializer: null
+}), _class);"
+`;
+
+exports[`Provider Arguments Transformer Testing with deprecated syntax Adds property name to @LateInject arguments @LateInject -> @LateInject("myDependency") 1`] = `
+"var _dec, _class, _descriptor;
+function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
+function _initializerWarningHelper(r, e) { throw Error("Decorating class property failed. Please ensure that transform-class-properties is enabled and runs after the decorators transform."); }
+let MainGraph = (_dec = lateInject("someString"), _class = class MainGraph {
+  someString = _initializerWarningHelper(_descriptor, this);
+}, _descriptor = _applyDecoratedDescriptor(_class.prototype, "someString", [_dec], {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  initializer: null
+}), _class);"
+`;
+
+exports[`Provider Arguments Transformer Testing with deprecated syntax Does not add name if name is provided by the user 1`] = `
+"var _dec, _class;
+function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
+let MainGraph = (_dec = provides({
+  name: 'myDependency'
+}), _class = class MainGraph {
+  someString({
+    stringProvider: stringProvider
+  }) {
+    return stringProvider.theString;
+  }
+}, _applyDecoratedDescriptor(_class.prototype, "someString", [_dec], Object.getOwnPropertyDescriptor(_class.prototype, "someString"), _class.prototype), _class);"
+`;
+
+exports[`Provider Arguments Transformer Testing with deprecated syntax Does not add property name to @Inject if name is provided by the user 1`] = `
+"var _dec, _class, _descriptor;
+function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
+function _initializerWarningHelper(r, e) { throw Error("Decorating class property failed. Please ensure that transform-class-properties is enabled and runs after the decorators transform."); }
+let MainGraph = (_dec = inject('myDependency'), _class = class MainGraph {
+  someString = _initializerWarningHelper(_descriptor, this);
+}, _descriptor = _applyDecoratedDescriptor(_class.prototype, "someString", [_dec], {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  initializer: null
+}), _class);"
+`;
+
+exports[`Provider Arguments Transformer Testing with deprecated syntax Does not add property name to @LateInject if name is provided by the user 1`] = `
+"var _dec, _class, _descriptor;
+function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
+function _initializerWarningHelper(r, e) { throw Error("Decorating class property failed. Please ensure that transform-class-properties is enabled and runs after the decorators transform."); }
+let MainGraph = (_dec = lateInject('myDependency'), _class = class MainGraph {
+  someString = _initializerWarningHelper(_descriptor, this);
+}, _descriptor = _applyDecoratedDescriptor(_class.prototype, "someString", [_dec], {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  initializer: null
+}), _class);"
+`;
+
+exports[`Provider Arguments Transformer Testing with deprecated syntax handles providers that have no arguments 1`] = `
+"var _dec, _class;
+function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
+let MainGraph = (_dec = provides({
+  name: "someString"
+}), _class = class MainGraph {
+  someString() {
+    return 'someString';
+  }
+}, _applyDecoratedDescriptor(_class.prototype, "someString", [_dec], Object.getOwnPropertyDescriptor(_class.prototype, "someString"), _class.prototype), _class);"
+`;
+
+exports[`Provider Arguments Transformer Testing with lowercase syntax Adds method name to provider arguments (@Provider() -> @Provider({name: "myProvidedDependency"}) 1`] = `
 "var _dec, _class;
 function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
 let MainGraph = (_dec = Provides({
@@ -15,7 +112,7 @@ let MainGraph = (_dec = Provides({
 }, _applyDecoratedDescriptor(_class.prototype, "someString", [_dec], Object.getOwnPropertyDescriptor(_class.prototype, "someString"), _class.prototype), _class);"
 `;
 
-exports[`Provider Arguments Transformer Adds property name to @Inject arguments @Inject -> @Inject("myDependency") 1`] = `
+exports[`Provider Arguments Transformer Testing with lowercase syntax Adds property name to @Inject arguments @Inject -> @Inject("myDependency") 1`] = `
 "var _dec, _class, _descriptor;
 function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
 function _initializerWarningHelper(r, e) { throw Error("Decorating class property failed. Please ensure that transform-class-properties is enabled and runs after the decorators transform."); }
@@ -29,7 +126,7 @@ let MainGraph = (_dec = Inject("someString"), _class = class MainGraph {
 }), _class);"
 `;
 
-exports[`Provider Arguments Transformer Adds property name to @LateInject arguments @LateInject -> @LateInject("myDependency") 1`] = `
+exports[`Provider Arguments Transformer Testing with lowercase syntax Adds property name to @LateInject arguments @LateInject -> @LateInject("myDependency") 1`] = `
 "var _dec, _class, _descriptor;
 function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
 function _initializerWarningHelper(r, e) { throw Error("Decorating class property failed. Please ensure that transform-class-properties is enabled and runs after the decorators transform."); }
@@ -43,7 +140,7 @@ let MainGraph = (_dec = LateInject("someString"), _class = class MainGraph {
 }), _class);"
 `;
 
-exports[`Provider Arguments Transformer Does not add name if name is provided by the user 1`] = `
+exports[`Provider Arguments Transformer Testing with lowercase syntax Does not add name if name is provided by the user 1`] = `
 "var _dec, _class;
 function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
 let MainGraph = (_dec = Provides({
@@ -57,7 +154,7 @@ let MainGraph = (_dec = Provides({
 }, _applyDecoratedDescriptor(_class.prototype, "someString", [_dec], Object.getOwnPropertyDescriptor(_class.prototype, "someString"), _class.prototype), _class);"
 `;
 
-exports[`Provider Arguments Transformer Does not add property name to @Inject if name is provided by the user 1`] = `
+exports[`Provider Arguments Transformer Testing with lowercase syntax Does not add property name to @Inject if name is provided by the user 1`] = `
 "var _dec, _class, _descriptor;
 function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
 function _initializerWarningHelper(r, e) { throw Error("Decorating class property failed. Please ensure that transform-class-properties is enabled and runs after the decorators transform."); }
@@ -71,7 +168,7 @@ let MainGraph = (_dec = Inject('myDependency'), _class = class MainGraph {
 }), _class);"
 `;
 
-exports[`Provider Arguments Transformer Does not add property name to @LateInject if name is provided by the user 1`] = `
+exports[`Provider Arguments Transformer Testing with lowercase syntax Does not add property name to @LateInject if name is provided by the user 1`] = `
 "var _dec, _class, _descriptor;
 function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
 function _initializerWarningHelper(r, e) { throw Error("Decorating class property failed. Please ensure that transform-class-properties is enabled and runs after the decorators transform."); }
@@ -85,7 +182,7 @@ let MainGraph = (_dec = LateInject('myDependency'), _class = class MainGraph {
 }), _class);"
 `;
 
-exports[`Provider Arguments Transformer handles providers that have no arguments 1`] = `
+exports[`Provider Arguments Transformer Testing with lowercase syntax handles providers that have no arguments 1`] = `
 "var _dec, _class;
 function _applyDecoratedDescriptor(i, e, r, n, l) { var a = {}; return Object.keys(n).forEach(function (i) { a[i] = n[i]; }), a.enumerable = !!a.enumerable, a.configurable = !!a.configurable, ("value" in a || a.initializer) && (a.writable = !0), a = r.slice().reverse().reduce(function (r, n) { return n(i, e, r) || r; }, a), l && void 0 !== a.initializer && (a.value = a.initializer ? a.initializer.call(l) : void 0, a.initializer = void 0), void 0 === a.initializer ? (Object.defineProperty(i, e, a), null) : a; }
 let MainGraph = (_dec = Provides({
@@ -95,11 +192,4 @@ let MainGraph = (_dec = Provides({
     return 'someString';
   }
 }, _applyDecoratedDescriptor(_class.prototype, "someString", [_dec], Object.getOwnPropertyDescriptor(_class.prototype, "someString"), _class.prototype), _class);"
-`;
-
-exports[`Provider Arguments Transformer saves constructor argument name in Inject - @Inject -> @Inject(arg) 1`] = `
-"class MainGraph {
-  constructor(@Inject("arg")
-  arg) {}
-}"
 `;

--- a/packages/react-obsidian/transformers/babel-plugin-obsidian/index.test.ts
+++ b/packages/react-obsidian/transformers/babel-plugin-obsidian/index.test.ts
@@ -1,93 +1,115 @@
+/* eslint-disable @stylistic/max-len */
 import * as babel from '@babel/core';
 import providerArgumentsTransformer from './index';
 
 const unnamedProvider = `class MainGraph {
-  @Provides()
+  @provides()
   someString(stringProvider, emptyString) {
     return stringProvider.theString + emptyString;
   }
 }`;
 
 const namedProvider = `class MainGraph {
-  @Provides({name: 'myDependency'})
+  @provides({name: 'myDependency'})
   someString(stringProvider) {
     return stringProvider.theString;
   }
 }`;
 
 const noArgsProvider = `class MainGraph {
-  @Provides()
+  @provides()
   someString() {
     return 'someString';
   }
 }`;
 
-const unnamedConstructorInject = `class MainGraph {
-  constructor(@Inject() arg) {}
-}`;
-
 const unnamedInject = `class MainGraph {
-  @Inject() someString;
+  @inject() someString;
 }`;
 
 const namedInject = `class MainGraph {
-  @Inject('myDependency') someString;
+  @inject('myDependency') someString;
 }`;
 
 const unnamedLateInject = `class MainGraph {
-  @LateInject() someString;
+  @lateInject() someString;
 }`;
 
 const namedLateInject = `class MainGraph {
-  @LateInject('myDependency') someString;
+  @lateInject('myDependency') someString;
 }`;
 
+const lowerCaseSyntax = {
+  unnamedProvider,
+  namedProvider,
+  noArgsProvider,
+  unnamedInject,
+  namedInject,
+  unnamedLateInject,
+  namedLateInject,
+};
+
+const deprecatedSyntax = {
+  unnamedProvider: unnamedProvider.replace('@provides', '@Provides'),
+  namedProvider: namedProvider.replace('@provides', '@Provides'),
+  noArgsProvider: noArgsProvider.replace('@provides', '@Provides'),
+  unnamedInject: unnamedInject.replace('@inject', '@Inject'),
+  namedInject: namedInject.replace('@inject', '@Inject'),
+  unnamedLateInject: unnamedLateInject.replace('@lateInject', '@LateInject'),
+  namedLateInject: namedLateInject.replace('@lateInject', '@LateInject'),
+};
+
+const testCases = [
+  {
+    description: 'Adds method name to provider arguments (@Provider() -> @Provider({name: "myProvidedDependency"})',
+    testCase: 'unnamedProvider',
+  },
+  {
+    description: 'Does not add name if name is provided by the user',
+    testCase: 'namedProvider',
+  },
+  {
+    description: 'handles providers that have no arguments',
+    testCase: 'noArgsProvider',
+  },
+  {
+    description: 'Adds property name to @Inject arguments @Inject -> @Inject("myDependency")',
+    testCase: 'unnamedInject',
+  },
+  {
+    description: 'Does not add property name to @Inject if name is provided by the user',
+    testCase: 'namedInject',
+  },
+  {
+    description: 'Adds property name to @LateInject arguments @LateInject -> @LateInject("myDependency")',
+    testCase: 'unnamedLateInject',
+  },
+  {
+    description: 'Does not add property name to @LateInject if name is provided by the user',
+    testCase: 'namedLateInject',
+  },
+] as const;
+
+const versions = [
+  { version: 'lowercase', syntax: deprecatedSyntax },
+  { version: 'deprecated', syntax: lowerCaseSyntax },
+];
+
 describe('Provider Arguments Transformer', () => {
-  const uut: Function = providerArgumentsTransformer;
+  const uut = providerArgumentsTransformer;
 
-  it('Adds method name to provider arguments (@Provider() -> @Provider({name: "myProvidedDependency"})', () => {
-    const result = transformSync(unnamedProvider);
-    expect(result?.code).toMatchSnapshot();
-  });
-
-  it('Does not add name if name is provided by the user', () => {
-    const result = transformSync(namedProvider);
-    expect(result?.code).toMatchSnapshot();
-  });
-
-  it('handles providers that have no arguments', () => {
-    const result = transformSync(noArgsProvider);
-    expect(result?.code).toMatchSnapshot();
-  });
-
-  it('saves constructor argument name in Inject - @Inject -> @Inject(arg)', () => {
-    const result = transformSync(unnamedConstructorInject);
-    expect(result?.code).toMatchSnapshot();
-  });
-
-  it('Adds property name to @Inject arguments @Inject -> @Inject("myDependency")', () => {
-    const result = transformSync(unnamedInject);
-    expect(result?.code).toMatchSnapshot();
-  });
-
-  it('Does not add property name to @Inject if name is provided by the user', () => {
-    const result = transformSync(namedInject);
-    expect(result?.code).toMatchSnapshot();
-  });
-
-  it('Adds property name to @LateInject arguments @LateInject -> @LateInject("myDependency")', () => {
-    const result = transformSync(unnamedLateInject);
-    expect(result?.code).toMatchSnapshot();
-  });
-
-  it('Does not add property name to @LateInject if name is provided by the user', () => {
-    const result = transformSync(namedLateInject);
-    expect(result?.code).toMatchSnapshot();
+  versions.forEach(({ version, syntax }) => {
+    describe(`Testing with ${version} syntax`, () => {
+      it.each(testCases)('$description', ({ testCase }) => {
+        const result = transformSync(syntax[testCase]);
+        expect(result?.code).toMatchSnapshot();
+      });
+    });
   });
 
   const transformSync = (snippet: string) => babel.transformSync(snippet, {
     plugins: [
-      ['@babel/plugin-proposal-decorators', { legacy: true }],
+      ['@babel/plugin-proposal-decorators', { version: 'legacy' }],
       uut,
     ],
     ast: true,

--- a/packages/react-obsidian/transformers/babel-plugin-obsidian/index.ts
+++ b/packages/react-obsidian/transformers/babel-plugin-obsidian/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import {
   ClassMethod,
   ClassProperty,
@@ -20,22 +19,27 @@ const providerArgumentsTransformer: PluginObj = {
 const internalVisitor = {
   ClassMethod: {
     enter({ node }: NodePath<ClassMethod>) {
+      unmagler.saveClassMethod('provides', node);
       unmagler.saveClassMethod('Provides', node);
     },
   },
   ClassProperty: {
     enter({ node }: NodePath<ClassProperty>) {
+      unmagler.saveClassProperty('inject', node);
+      unmagler.saveClassProperty('lateInject', node);
       unmagler.saveClassProperty('Inject', node);
       unmagler.saveClassProperty('LateInject', node);
     },
   },
   Identifier: {
     enter({ node }: NodePath<Identifier>) {
+      unmagler.saveIdentifier('inject', node);
       unmagler.saveIdentifier('Inject', node);
     },
   },
   TSParameterProperty: {
     enter({ node }: NodePath<TSParameterProperty>) {
+      unmagler.saveTSParameterProperty('inject', node);
       unmagler.saveTSParameterProperty('Inject', node);
     },
   },

--- a/packages/swc-plugin-obsidian/package.json
+++ b/packages/swc-plugin-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swc-plugin-obsidian",
-  "version": "2.17.0-alpha.1",
+  "version": "2.18.0-alpha.1",
   "description": "SWC plugin for Obsidian to be used with Vite or NextJS",
   "author": "Guy Carmeli",
   "main": "src/index.js",

--- a/packages/swc-plugin-obsidian/package.json
+++ b/packages/swc-plugin-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swc-plugin-obsidian",
-  "version": "2.17.0+alpha.1",
+  "version": "2.17.0-alpha.1",
   "description": "SWC plugin for Obsidian to be used with Vite or NextJS",
   "author": "Guy Carmeli",
   "main": "src/index.js",

--- a/packages/swc-plugin-obsidian/package.json
+++ b/packages/swc-plugin-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swc-plugin-obsidian",
-  "version": "2.16.0",
+  "version": "2.17.0+alpha.1",
   "description": "SWC plugin for Obsidian to be used with Vite or NextJS",
   "author": "Guy Carmeli",
   "main": "src/index.js",


### PR DESCRIPTION
This PR deprecates the existing capitalized decorators (e.g., `@Graph`) in favor of their lowercase equivalents (e.g., `@graph`) to aligns with the common JavaScript naming convention.