### PR TITLE
Remove constructor injection support

### DIFF
--- a/packages/documentation/docs/documentation/documentation.mdx
+++ b/packages/documentation/docs/documentation/documentation.mdx
@@ -132,33 +132,6 @@ const SomeComponent = () => {
 ```
 
   </TabItem>
-  <TabItem value="class" label="Class constructor injection">
-
-To inject a class, annotate it with the `@injectable` decorator. The `@injectable` decorator takes a single parameter - the graph that should be used to resolve the dependencies.
-Declare the dependencies as constructor parameters and annotate them with the `@inject` decorator.
-
-```ts title="MyClass.tsx"
-import {injectable, inject} from 'react-obsidian';
-import {ApplicationGraph} from './ApplicationGraph';
-
-@injectable(ApplicationGraph)
-export MyClass {
-  constructor (fooService?: FooService);
-  constructor(@Inject() private fooService: FooService) { }
-}
-```
-
-Now we can use the injected class without providing its dependencies manually:
-```ts
-const myClass = new MyClass();
-```
-
-Of course, passing dependencies explicitly is still possible:
-```ts
-const myClass = new MyClass(new FooService());
-```
-
-  </TabItem>
 </Tabs>
 
 ___

--- a/packages/react-obsidian/src/decorators/inject/Inject.ts
+++ b/packages/react-obsidian/src/decorators/inject/Inject.ts
@@ -1,17 +1,12 @@
-import { isNumber } from '../../utils/isNumber';
 import InjectionMetadata from '../../injectors/class/InjectionMetadata';
 
 export function inject(name?: string) {
   return (
     target: Object | any,
     _propertyKey?: string,
-    indexOrPropertyDescriptor?: number | PropertyDescriptor,
+    _indexOrPropertyDescriptor?: number | PropertyDescriptor,
   ) => {
     const metadata = new InjectionMetadata();
-    if (isNumber(indexOrPropertyDescriptor)) {
-      metadata.saveConstructorParamMetadata(target, name!, indexOrPropertyDescriptor);
-    } else {
       metadata.savePropertyMetadata(target.constructor, name!);
-    }
   };
 }

--- a/packages/react-obsidian/src/injectors/class/ClassInjector.ts
+++ b/packages/react-obsidian/src/injectors/class/ClassInjector.ts
@@ -32,9 +32,8 @@ export default class ClassInjector {
           referenceCounter.retain(graph);
         }
         Reflect.defineMetadata(GRAPH_INSTANCE_NAME_KEY, graph.name, target);
-        const argsToInject = this.injectConstructorArgs(args, graph, target);
         graph.onBind(target);
-        const createdObject = Reflect.construct(target, argsToInject, newTarget);
+        const createdObject = Reflect.construct(target, args, newTarget);
         this.injectProperties(target, createdObject, graph);
         const originalComponentWillUnmount = createdObject.componentWillUnmount;
         createdObject.componentWillUnmount = () => {
@@ -42,14 +41,6 @@ export default class ClassInjector {
           referenceCounter.release(graph, (g) => graphRegistry.clear(g));
         };
         return createdObject;
-      }
-
-      private injectConstructorArgs(args: any[], graph: Graph, target: any): any[] {
-        const argsToInject = injectionMetadata.getConstructorArgsToInject(target);
-        if (!argsToInject.hasArgs()) return args;
-        return [...args, ...new Array(Math.abs(args.length - argsToInject.size()))].map((value, idx): any => {
-          return value ?? graph.retrieve(argsToInject.getProperty(idx));
-        });
       }
 
       private injectProperties(target: any, createdObject: any, graph: Graph) {

--- a/packages/react-obsidian/src/injectors/class/InjectionMetadata.ts
+++ b/packages/react-obsidian/src/injectors/class/InjectionMetadata.ts
@@ -18,16 +18,6 @@ export default class InjectionMetadata {
     return this.getProperties(this.lateInjectionMetadataKey, target);
   }
 
-  saveConstructorParamMetadata(target: any, paramName: string, index: number) {
-    const argsToInject = this.getConstructorArgsToInject(target);
-    argsToInject.add(paramName, index);
-    Reflect.defineMetadata(
-      this.injectedConstructorArgsKey,
-      argsToInject,
-      target,
-    );
-  }
-
   savePropertyMetadata(target: any, property: string) {
     this.saveProperties(
       this.injectionMetadataKey,

--- a/packages/react-obsidian/src/utils/isNumber.ts
+++ b/packages/react-obsidian/src/utils/isNumber.ts
@@ -1,3 +1,0 @@
-export function isNumber(value: unknown): value is number {
-  return typeof value === 'number';
-}

--- a/packages/react-obsidian/test/integration/classInjection.test.tsx
+++ b/packages/react-obsidian/test/integration/classInjection.test.tsx
@@ -14,29 +14,6 @@ describe('Class injection', () => {
     expect(uut.targetName).toBe('ClassToTestOnBind');
   });
 
-  // it('injects constructor arguments', () => {
-  //   const uut = new SingleArg();
-  //   expect(uut.anotherString).toBe(injectedValues.anotherString);
-  // });
-
-  // it('injects multiple constructor arguments', () => {
-  //   const uut = new MultiArg();
-  //   expect(uut.someString).toBe(injectedValues.fromStringProvider);
-  //   expect(uut.anotherString).toBe(injectedValues.anotherString);
-  // });
-
-  // it('only injects if constructor arg is undefined', () => {
-  //   const uut = new MultiArg('override');
-  //   expect(uut.someString).toBe('override');
-  //   expect(uut.anotherString).toBe(injectedValues.anotherString);
-  // });
-
-  // it('injects simple constructor args', () => {
-  //   const uut = new SimpleArgs();
-  //   expect(uut.someString).toBe(injectedValues.fromStringProvider);
-  //   expect(uut.anotherString).toBe(injectedValues.anotherString);
-  // });
-
   it('injects properties from a registered graph', () => {
     Obsidian.registerGraph('main', () => MainGraph);
     const uut = new ClassToTestRegisteredGraph();


### PR DESCRIPTION
This PR removes support for injecting constructor parameters. Unfortunately this feature relied on undocumented behavior of `@babel/plugin-proposal-decorators` which broke a while ago. There was an attempt to revive this feature a few years ago but it relied on an abandoned Babel plugin - [babel-plugin-typescript-decorators](https://github.com/wmzy/babel-plugin-typescript-decorators).