### PR TITLE
Bail when property is retrieved instead of evaluating the entire graph

### DIFF
--- a/packages/eslint-plugin-obsidian/package.json
+++ b/packages/eslint-plugin-obsidian/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-obsidian",
   "description": "ESLint rules for Obsidian",
   "main": "dist/index.js",
-  "version": "2.21.0",
+  "version": "2.22.0-alpha.1",
   "scripts": {
     "build": "npx tsc --project tsconfig.prod.json",
     "test": "npx jest",

--- a/packages/react-obsidian/package.json
+++ b/packages/react-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-obsidian",
-  "version": "2.21.0",
+  "version": "2.22.0-alpha.1",
   "description": "Dependency injection framework for React and React Native applications",
   "scripts": {
     "prepack": "yarn lint && tsc --project tsconfig.prod.json",

--- a/packages/react-obsidian/src/graph/PropertyRetriever.ts
+++ b/packages/react-obsidian/src/graph/PropertyRetriever.ts
@@ -38,26 +38,18 @@ export default class PropertyRetriever {
       );
     }
 
-    const results = this.getFromSubgraphs(property, circularDependenciesDetector, receiver);
-    if (results.length === 1) return results[0];
-    if (results.length > 1) {
-      throw new Error(
-        `Multiple subgraphs provide the property ${property}.`
-        + 'You should probably provide a unique name to one of the providers: @Provide({name: \'uniqueName\')})',
-      );
-    }
-    return undefined;
+    return this.getFromSubgraphs(property, circularDependenciesDetector, receiver);
   }
 
   private getFromSubgraphs(
     property: string,
     circularDependenciesDetector: CircularDependenciesDetector,
     receiver: unknown,
-  ): unknown[] {
+  ): unknown | undefined {
     for (const subgraph of graphRegistry.getSubgraphs(this.graph)) {
       const result = subgraph.retrieve(property, receiver, circularDependenciesDetector);
-      if (result) return [result];
+      if (result) return result;
     }
-    return [];
+    return undefined;
   }
 }

--- a/packages/react-obsidian/src/graph/PropertyRetriever.ts
+++ b/packages/react-obsidian/src/graph/PropertyRetriever.ts
@@ -2,10 +2,10 @@ import graphRegistry from './registry/GraphRegistry';
 import { Graph } from './Graph';
 import providedPropertiesStore from '../ProvidedPropertiesStore';
 import { CircularDependenciesDetector } from './CircularDependenciesDetector';
-import {Reflect} from '../utils/reflect';
+import { Reflect } from '../utils/reflect';
 
 export default class PropertyRetriever {
-  constructor(private graph: Graph) { }
+  constructor (private graph: Graph) { }
 
   retrieve(
     property: string,
@@ -33,8 +33,8 @@ export default class PropertyRetriever {
     if (circularDependenciesDetector.hasCircularDependencies()) {
       throw new Error(
         `Could not resolve ${circularDependenciesDetector.firstDependencyName}`
-         + ` from ${circularDependenciesDetector.graphName} because of a circular dependency:`
-         + ` ${circularDependenciesDetector.getDependencies().join(' -> ')}`,
+        + ` from ${circularDependenciesDetector.graphName} because of a circular dependency:`
+        + ` ${circularDependenciesDetector.getDependencies().join(' -> ')}`,
       );
     }
 

--- a/packages/react-obsidian/src/graph/PropertyRetriever.ts
+++ b/packages/react-obsidian/src/graph/PropertyRetriever.ts
@@ -54,9 +54,10 @@ export default class PropertyRetriever {
     circularDependenciesDetector: CircularDependenciesDetector,
     receiver: unknown,
   ): unknown[] {
-    const subgraphs = graphRegistry.getSubgraphs(this.graph);
-    return subgraphs
-      .map((subgraph: Graph) => subgraph.retrieve(property, receiver, circularDependenciesDetector))
-      .filter((result) => result !== undefined);
+    for (const subgraph of graphRegistry.getSubgraphs(this.graph)) {
+      const result = subgraph.retrieve(property, receiver, circularDependenciesDetector);
+      if (result) return [result];
+    }
+    return [];
   }
 }

--- a/packages/react-obsidian/test/acceptance/singletonGraphSharedByMultipleSubgraphs.test.ts
+++ b/packages/react-obsidian/test/acceptance/singletonGraphSharedByMultipleSubgraphs.test.ts
@@ -8,7 +8,7 @@ import {
 
 describe('Singleton graph shared by multiple subgraphs', () => {
   it('should be able to retrieve a singleton from a subgraph', () => {
-    expect(Obsidian.obtain(AppGraph).AppClient()).toBe('AppClienthttpClient');
+    expect(Obsidian.obtain(AppGraph).appClient()).toBe('AppClienthttpClient');
   });
 });
 
@@ -39,7 +39,7 @@ class Model2Graph extends ObjectGraph {
 @singleton() @graph({ subgraphs: [Model1Graph, Model2Graph] })
 class AppGraph extends ObjectGraph {
   @provides()
-  AppClient(httpClient: any) {
+  appClient(httpClient: any) {
     return 'AppClient' + httpClient;
   }
 }

--- a/packages/react-obsidian/test/acceptance/singletonGraphSharedByMultipleSubgraphs.test.ts
+++ b/packages/react-obsidian/test/acceptance/singletonGraphSharedByMultipleSubgraphs.test.ts
@@ -1,0 +1,46 @@
+import {
+  graph,
+  ObjectGraph,
+  Obsidian,
+  provides,
+  singleton,
+} from '../../src';
+
+describe('Singleton graph shared by multiple subgraphs', () => {
+  it('should be able to retrieve a singleton from a subgraph', () => {
+    expect(Obsidian.obtain(AppGraph).AppClient()).toBe('AppClienthttpClient');
+  });
+});
+
+@singleton() @graph()
+class NetworkGraph extends ObjectGraph {
+  @provides()
+  httpClient() {
+    return 'httpClient';
+  }
+}
+
+@singleton() @graph({ subgraphs: [NetworkGraph] })
+class Model1Graph extends ObjectGraph {
+  @provides()
+  model1(httpClient: string) {
+    return 'model1' + httpClient;
+  }
+}
+
+@singleton() @graph({ subgraphs: [NetworkGraph] })
+class Model2Graph extends ObjectGraph {
+  @provides()
+  model2(httpClient: string) {
+    return 'model2' + httpClient;
+  }
+}
+
+@singleton() @graph({ subgraphs: [Model1Graph, Model2Graph] })
+class AppGraph extends ObjectGraph {
+  @provides()
+  AppClient(httpClient: any) {
+    return 'AppClient' + httpClient;
+  }
+}
+

--- a/packages/swc-plugin-obsidian/package.json
+++ b/packages/swc-plugin-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swc-plugin-obsidian",
-  "version": "2.21.0",
+  "version": "2.22.0-alpha.1",
   "description": "SWC plugin for Obsidian to be used with Vite or NextJS",
   "author": "Guy Carmeli",
   "main": "src/index.js",


### PR DESCRIPTION
Fixes #226 

TODO
- [x] Remove exception entirely - it's not even tested
- [x] Open issue - Replace `getSubgraphs()` with a `getSubgraphsIterator()` that will allow us to iterate lazily over subgraphs instead of prematurely instantiating all subgraphs.