### PR TITLE
Look for dependencies in nested subgraphs

### DIFF
--- a/packages/vscode-language-server-obsidian/package.json
+++ b/packages/vscode-language-server-obsidian/package.json
@@ -4,7 +4,7 @@
   "description": "Intellisense support for Obsidian dependency injection framework",
   "publisher": "guycarmeli",
   "icon": "obsidian.png",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "ISC",
   "main": "./client/dist/extension.js",
   "scripts": {

--- a/packages/vscode-language-server-obsidian/server/src/dto/graph.ts
+++ b/packages/vscode-language-server-obsidian/server/src/dto/graph.ts
@@ -20,11 +20,9 @@ export class Graph {
   }
 
   private requireProviderFromSubgraphs(providerName: string): Provider {
-    const subgraphs = this.getSubgraphs();
-    for (const graph of subgraphs) {
-      if (graph.hasProvider(providerName)) {
-        return graph.resolveProvider(providerName);
-      }
+    for (const graph of this.getSubgraphs()) {
+      const result = graph.resolveProvider(providerName);
+      if (result) return result;
     }
     throw new Error(`Provider ${providerName} not found in graph ${this.node.getName()}`);
   }

--- a/packages/vscode-language-server-obsidian/server/tests/integration/definition/handled/dependencyInNestedSubgraph/index.ts
+++ b/packages/vscode-language-server-obsidian/server/tests/integration/definition/handled/dependencyInNestedSubgraph/index.ts
@@ -1,0 +1,24 @@
+import { DefinitionTestCase } from "../../..";
+import * as path from 'path';
+
+export default {
+  name: 'dependency in nested subgraph',
+  entryPoint: path.resolve(__dirname, './sourceCodes/entryPoint.ts'),
+  position: {
+    line: 7,
+    character: 8
+  },
+  result: {
+    uri: path.resolve(__dirname, './sourceCodes/networkGraph.ts'),
+    range: {
+      start: {
+        line: 5,
+        character: 2
+      },
+      end: {
+        line: 8,
+        character: 4
+      }
+    }
+  }
+} satisfies DefinitionTestCase;

--- a/packages/vscode-language-server-obsidian/server/tests/integration/definition/handled/dependencyInNestedSubgraph/sourceCodes/entryPoint.ts
+++ b/packages/vscode-language-server-obsidian/server/tests/integration/definition/handled/dependencyInNestedSubgraph/sourceCodes/entryPoint.ts
@@ -1,0 +1,11 @@
+import { graph, ObjectGraph, provides, singleton } from 'react-obsidian';
+import { FrameworkGraph } from './frameworkGraph';
+import { type Window } from './window';
+
+@singleton() @graph({ subgraphs: [FrameworkGraph] })
+export class ThemeGraph extends ObjectGraph {
+  @provides()
+  bar(_httpClient: any, _window: Window) {
+    return 'bar';
+  }
+}

--- a/packages/vscode-language-server-obsidian/server/tests/integration/definition/handled/dependencyInNestedSubgraph/sourceCodes/frameworkGraph.ts
+++ b/packages/vscode-language-server-obsidian/server/tests/integration/definition/handled/dependencyInNestedSubgraph/sourceCodes/frameworkGraph.ts
@@ -1,0 +1,11 @@
+import { graph, ObjectGraph, provides, singleton } from 'react-obsidian';
+import { Window } from './window';
+import { NetworkGraph } from './networkGraph';
+
+@singleton() @graph({ subgraphs: [NetworkGraph] })
+export class FrameworkGraph extends ObjectGraph {
+  @provides()
+  window(): Window {
+    return new Window(window);
+  }
+}

--- a/packages/vscode-language-server-obsidian/server/tests/integration/definition/handled/dependencyInNestedSubgraph/sourceCodes/networkGraph.ts
+++ b/packages/vscode-language-server-obsidian/server/tests/integration/definition/handled/dependencyInNestedSubgraph/sourceCodes/networkGraph.ts
@@ -1,0 +1,9 @@
+import { graph, ObjectGraph, provides, singleton } from 'react-obsidian';
+
+@singleton() @graph()
+export class NetworkGraph extends ObjectGraph {
+  @provides()
+  httpClient() {
+    return 'httpClient';
+  }
+}

--- a/packages/vscode-language-server-obsidian/server/tests/integration/definition/handled/dependencyInNestedSubgraph/sourceCodes/window.ts
+++ b/packages/vscode-language-server-obsidian/server/tests/integration/definition/handled/dependencyInNestedSubgraph/sourceCodes/window.ts
@@ -1,0 +1,21 @@
+export class Window {
+  constructor (private theWindow: typeof window) { }
+
+  public get currentColorScheme(): 'dark' | 'light' {
+    return this.isDarkMode ? 'dark' : 'light';
+  }
+
+  public get isDarkMode(): boolean {
+    return this.theWindow.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+
+  public registerPreferredColorSchemeChangeListener(
+    onColorSchemeChange: (colorScheme: 'dark' | 'light') => void,
+  ) {
+    this.theWindow
+      .matchMedia('(prefers-color-scheme: dark)')
+      .addListener((e) => {
+        onColorSchemeChange(e.matches ? 'dark' : 'light');
+      });
+  }
+}

--- a/packages/vscode-language-server-obsidian/server/tests/integration/definition/handled/goTodefinition.handled.test.ts
+++ b/packages/vscode-language-server-obsidian/server/tests/integration/definition/handled/goTodefinition.handled.test.ts
@@ -15,6 +15,7 @@ import dependencyInExportDefaultSubgraph from "./dependencyInExportDefaultSubgra
 import { createParams } from "../../utils/createParams";
 import { createTestProjectAdapter } from "../../utils/createTestProjectAdapter";
 import { FakeLogger } from "../../fakes/fakeLogger";
+import dependencyInNestedSubgraph from "./dependencyInNestedSubgraph";
 
 const testCases: DefinitionTestCase[] = [
   injectedHook,
@@ -27,7 +28,8 @@ const testCases: DefinitionTestCase[] = [
   injectedClassDependenciesOfTypeAlias,
   injectedHookTypedProvider,
   injectedExportDefaultGraph,
-  dependencyInExportDefaultSubgraph
+  dependencyInExportDefaultSubgraph,
+  dependencyInNestedSubgraph
 ];
 
 describe('GoToDefinition', () => {


### PR DESCRIPTION
This fixes a bug in the vscode extension where go to definition did not work if the dependency was provided by a nested subgraph